### PR TITLE
Notify stream-creator of stream stop

### DIFF
--- a/src/aiko_services/main/pipeline.py
+++ b/src/aiko_services/main/pipeline.py
@@ -926,6 +926,18 @@ class PipelineImpl(Pipeline):
 
                     stream.set_state(self._process_stream_event(element_name,
                         stream_event, diagnostic, in_destroy_stream=True))
+
+            if stream.state == StreamState.RUN:
+                stream.state = StreamState.STOP
+            stream_info = {
+                "stream_id": stream.stream_id,
+                "frame_id": stream.frame_id,
+                "state": stream.state}
+            if stream.queue_response:
+                stream.queue_response.put((stream_info, {}))
+            if stream.topic_response:
+                actor = get_actor_mqtt(stream.topic_response, Pipeline)
+                actor.process_frame_response(stream_info, {})
         finally:
             if use_thread_local:
                 stream.lock.release()


### PR DESCRIPTION
A stream creator might pass a queue_response or topic response when calling create_stream(), so it can be notified as frames are processed.
This change also posts to the queue and/or topic when the stream is destroyed.