### PR TITLE
BUGFIX: release lock if process_frame return StreamEvent.ERROR

### DIFF
--- a/src/aiko_services/main/pipeline.py
+++ b/src/aiko_services/main/pipeline.py
@@ -904,6 +904,7 @@ class PipelineImpl(Pipeline):
             if use_thread_local:
                 self._enable_thread_local("destroy_stream()", stream_id)
             stream, _ = self.get_stream()
+
             stream.lock.acquire("destroy_stream()")
 
             if graceful and len(stream.frames):
@@ -1175,6 +1176,9 @@ class PipelineImpl(Pipeline):
                             stream_event = StreamEvent.ERROR
                             frame_data_out = {
                                 "diagnostic": traceback.format_exc()}
+
+                        if stream_event == StreamEvent.ERROR:
+                            stream.lock.release()
 
                         stream.set_state(self._process_stream_event(
                             element_name, stream_event, frame_data_out))


### PR DESCRIPTION
this PR fixes a deadlock when an error is raised in process_frame. 

Process frame acquires a lock, and is released when a stream is destroyed. However, the lock is not released when an error occurs in process_frame.

Thanks to @tall-josh for finding and helping fix this issue.