### PR TITLE
Fix main/pipeline.py to maintain the stream.lock when calling destroy_stream() in an error condition

### DIFF
--- a/src/aiko_services/main/pipeline.py
+++ b/src/aiko_services/main/pipeline.py
@@ -1014,7 +1014,10 @@ class PipelineImpl(Pipeline):
             self._disable_thread_local("create_stream()")
         return True
 
-    def destroy_stream(self, stream_id, graceful=False, use_thread_local=True):
+    def destroy_stream(self, stream_id,
+                       graceful=False,
+                       use_thread_local=True,
+                       with_lock=False):
         stream_id = str(stream_id)
 
     # TODO: Proper solution for handling of remote Pipeline proxy
@@ -1046,7 +1049,8 @@ class PipelineImpl(Pipeline):
             if use_thread_local:
                 self._enable_thread_local("destroy_stream()", stream_id)
             stream, _ = self.get_stream()
-            stream.lock.acquire("destroy_stream()")
+            if not with_lock:
+                stream.lock.acquire("destroy_stream()")
 
             if graceful and len(stream.frames):
                 arguments = [stream_id, graceful, use_thread_local]
@@ -1576,9 +1580,7 @@ class PipelineImpl(Pipeline):
             stream_state = StreamState.ERROR
             self.logger.error(get_diagnostic(diagnostic))
             if not in_destroy_stream:  # avoid destroy_stream() recursion
-                if stream.lock._in_use:
-                    stream.lock.release()
-                self.destroy_stream(get_stream_id(), use_thread_local=False)
+                self.destroy_stream(get_stream_id(), use_thread_local=False, with_lock=stream.lock._in_use)
 
         return stream_state
 


### PR DESCRIPTION
Currently when an error is raised, _process_stream_event() will call destroy_stream() directly so that the stream is immediately terminated and cleaned up.
However, _process_stream_event() releases stream.lock before calling destroy_stream(), allowing another thread to update stream.state before destroy_stream() can stop and clean-up the stream, meaning that stream.state cannot be used to signal that an error condition has occurred.