### PR TITLE
Put json.load in file open context

### DIFF
--- a/src/aiko_services/main/pipeline.py
+++ b/src/aiko_services/main/pipeline.py
@@ -1128,8 +1128,8 @@ class PipelineImpl(Pipeline):
         PARAMETERS_FIELD = "parameters"
         header = f"Error: Parsing PipelineDefinition: {pipeline_definition_pathname}"
         try:
-            pipeline_definition_dict = json.load(
-                open(pipeline_definition_pathname, "r"))
+            with open(pipeline_definition_pathname, "r") as f:
+                pipeline_definition_dict = json.load(f)
             PipelineDefinitionSchema.validate(pipeline_definition_dict)
         except ValueError as value_error:
             PipelineImpl._exit(header, value_error)


### PR DESCRIPTION
Fix 

```
src/aiko_services/main/pipeline.py:1167: ResourceWarning: unclosed file <_io.TextIOWrapper name='/tmp/nix-shell-3953057-0/tmp8lh7z89i/pip
eline_def.json' mode='r' encoding='UTF-8'>                                                                                                                                                    
  pipeline_definition_dict = json.load(                                                                                                                                                       
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```