### PR TITLE
Add support for URLs with scheme 'data:'

### DIFF
--- a/src/aiko_services/main/scheme.py
+++ b/src/aiko_services/main/scheme.py
@@ -48,12 +48,16 @@ class DataScheme:
 
     @classmethod
     def parse_data_url_path(cls, data_url):  # data_source or data_target
+        if data_url.startswith("data:"):
+            raise NotImplementedError("'data:' URLs do not have a path component")
         tokens = data_url.split("://")  # URL "scheme://path" or "path"
         path = tokens[0] if len(tokens) == 1 else tokens[1]
         return path
 
     @classmethod
     def parse_data_url_scheme(cls, data_url):  # data_source or data_target
+        if data_url.startswith("data:"):
+            return "data"
         tokens = data_url.split("://")  # URL "scheme://path"
         scheme = "file" if len(tokens) == 1 else tokens[0]
         return scheme.lower()


### PR DESCRIPTION
For writing tests, it's useful to encode frame data directly in a URL according to https://developer.mozilla.org/en-US/docs/Web/URI/Reference/Schemes/data

Note: I'm not sure how to implement this scheme handler in Aiko, as the framing should be done in a way that's specific to the media-type of the data.