### PR TITLE
Explicitly close files to prevent resource leak

### DIFF
--- a/src/aiko_services/main/process_manager.py
+++ b/src/aiko_services/main/process_manager.py
@@ -311,12 +311,15 @@ class ProcessManagerImpl(ProcessManager):
         if definition_pathname:
             if definition_pathname.endswith(".json"):
                 try:
-                    commands = json.load(open(definition_pathname, "r"))
+                    with open(definition_pathname, "r") as file:
+                        commands = json.load(file)
                     for command in commands:
                         command = command.split()
                         self.create(command[0], command[1:])
                 except json.decoder.JSONDecodeError as json_decode_error:
                     diagnostic = f"Definition format: {json_decode_error}"
+                except OSError as os_error:
+                    diagnostic = f"Failed to open definition file: {os_error}"
             else:
                 diagnostic = 'Definition must be a ".json" file: ' +  \
                     definition_pathname


### PR DESCRIPTION
This pull request fixes a file-handling issue in `aiko_services/main/process_manager.py`. The previous implementation used `open()` without explicitly closing the file, which could lead to resource leaks. While Python’s garbage collector will eventually close unreferenced files, it is better practice to manage file lifetimes explicitly using a context manager.

This change replaces the direct `open()` call with a `with` statement to ensure proper file closure and expands the error handling to cover exceptions that may occur during file access. The issue was identified during an ongoing research project.