### PR TITLE
Fix incorrect dictionary cleanup for binary topics (issue #54)

### DIFF
--- a/src/aiko_services/main/process.py
+++ b/src/aiko_services/main/process.py
@@ -225,7 +225,7 @@ class ProcessImplementation(ProcessData):
             if len(self._message_handlers[topic]) == 0:
                 del self._message_handlers[topic]
                 if topic in self._message_handlers_binary_topics:
-                    del self._message_handlers_wildcard_topics[topic]
+                    del self._message_handlers_binary_topics[topic]
                 if topic in self._message_handlers_wildcard_topics:
                     del self._message_handlers_wildcard_topics[topic]
                 if self.message:


### PR DESCRIPTION
Correct remove_message_handler() to delete topics from _message_handlers_binary_topics instead of
_message_handlers_wildcard_topics when cleaning up binary non-wildcard handlers.

This prevents a KeyError and ensures internal handler tracking dictionaries remain consistent.

This resolves issue #54