### PR TITLE
Feat/example locate anything

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ dependencies = [
     "click~=8.1.7",
     "numpy>=1.26.4",
     "paho-mqtt>=1.6.1,<2.0.0",
-    "Pillow~=10.4.0",
+    "Pillow~=10.4.0; python_version<'3.14'",
+    "Pillow>=11.0.0; python_version>='3.14'",
     "psutil~=6.0.0",
     "pyperclip~=1.9.0",
     "pytest~=8.3.4",
@@ -50,7 +51,24 @@ dependencies = [
     "wrapt~=1.16.0"
 ]
 
-# [project.optional-dependencies]
+[project.optional-dependencies]
+# Inference deps for examples/locate_anything (LocateAnythingWorker).
+# locateanything_worker.py is not on PyPI; add Embodied to PYTHONPATH, e.g.:
+#   export PYTHONPATH=$PYTHONPATH:~/dev/open-source/vla-models/eagle/Embodied
+# decord is not on PyPI for macOS; locate_anything.py adds stubs/decord automatically.
+locate_anything = [
+    "accelerate>=1.5.2",
+    "einops",
+    "lmdb",
+    "opencv-python-headless>=4.10.0",
+    "peft>=0.12.0",
+    "sentencepiece>=0.2.0",
+    "timm>=1.0.11",
+    "tokenizers>=0.22.0",
+    "torch>=2.0",
+    "torchvision>=0.15.0",
+    "transformers>=4.57.1,<5",
+]
 # opencv-python = ["opencv-python~=4.10.0.84"]
 # opencv-contrib-python = ["opencv-contrib-python~=4.10.0.84"]
 # linux = ["PyAudio~=0.2.14"]

--- a/src/aiko_services/examples/locate_anything/locate_anything.py
+++ b/src/aiko_services/examples/locate_anything/locate_anything.py
@@ -43,17 +43,10 @@ _LOCATE_ANYTHING_MODEL_PATHNAME = "nvidia/LocateAnything-3B"
 
 # --------------------------------------------------------------------------- #
 # Default categories for robotdog detection
-# tennis_ball, kong_ball, rubber_ball, dog_biscuit
-# blue_cup, red_cup, orange_cone
-# stop_sign, sign
-# octopus, red_ball, green_ball, building
-# pine_tree, oak_tree, xgomini2
 
 _ROBOTDOG_CATEGORIES = [
-    "tennis_ball", "kong_ball", "rubber_ball", "dog_biscuit",
-    "blue_cup", "red_cup", "orange_cone",
-    "stop_sign", "sign",
-    "octopus", "red_ball", "green_ball", "building",
+    "tennis_ball", "kong_ball", "rubber_ball", "dog_biscuit", "blue_cup", "red_cup",
+    "orange_cone", "stop_sign", "sign", "octopus", "red_ball", "green_ball", "building",
     "pine_tree", "oak_tree", "xgomini2",
 ]
 

--- a/src/aiko_services/examples/locate_anything/locate_anything.py
+++ b/src/aiko_services/examples/locate_anything/locate_anything.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""LocateAnything object detector for aiko_services pipelines.
+
+Adapted from ``examples/yolo/yolo.py`` (``YoloDetector``).
+
+Setup (from the aiko_services repo root)::
+
+    pip install -e ".[locate_anything]"
+
+``locateanything_worker`` is not on PyPI. Add Embodied to ``PYTHONPATH``::
+
+    export PYTHONPATH=$PYTHONPATH:path/to/eagle/Embodied
+
+Run the example pipeline (from this directory)::
+
+    aiko_pipeline create locate_anything_pipeline_0.json -s 1
+
+    AIKO_LOG_LEVEL=DEBUG aiko_pipeline create locate_anything_pipeline_0.json -s 1
+
+    aiko_pipeline create locate_anything_pipeline_0.json -s 1 \\
+      -sp VideoReadWebcam.path /dev/video2  # Linux
+"""
+
+import re
+import sys
+from pathlib import Path
+from typing import Tuple
+
+import aiko_services as aiko
+from aiko_services.elements.media import convert_image_to_pil
+from aiko_services.main.utilities import parse
+
+__all__ = [ "LocateAnythingDetector" ]
+
+_STUBS_DIR = Path(__file__).resolve().parent / "stubs"
+if _STUBS_DIR.is_dir():
+    stubs_path = str(_STUBS_DIR)
+    if stubs_path not in sys.path:
+        sys.path.insert(0, stubs_path)
+    import decord  # noqa: F401  # satisfy transformers import check
+
+_LOCATE_ANYTHING_MODEL_PATHNAME = "nvidia/LocateAnything-3B"
+
+# --------------------------------------------------------------------------- #
+# Default categories for robotdog detection
+# tennis_ball, kong_ball, rubber_ball, dog_biscuit
+# blue_cup, red_cup, orange_cone
+# stop_sign, sign
+# octopus, red_ball, green_ball, building
+# pine_tree, oak_tree, xgomini2
+
+_ROBOTDOG_CATEGORIES = [
+    "tennis_ball", "kong_ball", "rubber_ball", "dog_biscuit",
+    "blue_cup", "red_cup", "orange_cone",
+    "stop_sign", "sign",
+    "octopus", "red_ball", "green_ball", "building",
+    "pine_tree", "oak_tree", "xgomini2",
+]
+
+import torch
+from locateanything_worker import LocateAnythingWorker
+
+
+class LocateAnythingDetector(aiko.PipelineElement):
+    
+    _REF_BOX_PATTERN = re.compile(
+        r"<ref>([^<]+)</ref>((?:<box>.*?</box>)+)")
+    _BOX_PATTERN = re.compile(
+        r"<box>\s*<\s*(\d+)\s*>\s*"
+        r"<\s*(\d+)\s*>\s*"
+        r"<\s*(\d+)\s*>\s*"
+        r"<\s*(\d+)\s*>\s*</box>")
+
+    def __init__(self, context):
+        context.set_protocol("object_detector:0")
+        context.call_init(self, "PipelineElement", context)
+
+    def start_stream(self, stream, stream_id):
+        self.device = "mps" if torch.backends.mps.is_available() else "cpu"
+        self.device = "cuda" if torch.cuda.is_available() else self.device
+
+        locate_anything_model_pathname, _ = self.get_parameter(
+            "model", default=_LOCATE_ANYTHING_MODEL_PATHNAME)
+
+        self.worker = LocateAnythingWorker(
+            locate_anything_model_pathname, device=self.device)
+
+        names, _ = self.get_parameter("names", default="()")
+        names = parse(names, car_cdr=False)
+        if isinstance(names, list) and len(names) and names[0] != "":
+            self.categories = names
+        else:
+            self.categories = list(_ROBOTDOG_CATEGORIES)
+            self.logger.warning(
+                'Parameter "names" must be a list; using default categories')
+        return aiko.StreamEvent.OKAY, {}
+
+    def _parse_detections(self, answer: str, image_width: int, image_height: int):
+        """Parse <ref>category</ref><box>... detection output into overlay entries."""
+        detections = []
+        for category, boxes_str in self._REF_BOX_PATTERN.findall(answer):
+            for x1, y1, x2, y2 in self._BOX_PATTERN.findall(boxes_str):
+                x1, y1, x2, y2 = map(int, (x1, y1, x2, y2))
+                x_min = int(min(x1, x2) / 1000 * image_width)
+                y_min = int(min(y1, y2) / 1000 * image_height)
+                x_max = int(max(x1, x2) / 1000 * image_width)
+                y_max = int(max(y1, y2) / 1000 * image_height)
+                detections.append((
+                    category,
+                    x_min,
+                    y_min,
+                    max(0, x_max - x_min),
+                    max(0, y_max - y_min),
+                ))
+        return detections
+
+    def process_frame(self, stream, images) -> Tuple[aiko.StreamEvent, dict]:
+        overlay = {"objects": [], "rectangles": []}
+        objects = overlay["objects"]
+        rectangles = overlay["rectangles"]
+
+        image_id = 0
+        for image in images:
+            pil_image = convert_image_to_pil(image)
+            image_width, image_height = pil_image.size
+
+            result = self.worker.detect(
+                pil_image, self.categories, verbose=False)
+            box_id = 0
+            for name, x, y, w, h in self._parse_detections(
+                    result["answer"], image_width, image_height):
+                confidence = 1.0
+                objects.append({"name": name, "confidence": confidence})
+                rectangles.append({"x": x, "y": y, "w": w, "h": h})
+
+                #   print(f"{name}: c: {confidence:0.2f}: "  \
+                #         f"i{image_id}: d{detection_id}: b{box_id}")
+                box_id += 1
+            image_id += 1
+
+        return aiko.StreamEvent.OKAY, {"overlay": overlay}
+
+# --------------------------------------------------------------------------- #

--- a/src/aiko_services/examples/locate_anything/locate_anything_pipeline_0.json
+++ b/src/aiko_services/examples/locate_anything/locate_anything_pipeline_0.json
@@ -1,0 +1,65 @@
+{
+    "#": "Adapted from examples/yolo/yolo_pipeline_0.json",
+    "version": 0,
+    "name":    "p_locate_anything",
+    "runtime": "python",
+  
+    "graph": [ "(VideoReadWebcam ImageResize LocateAnythingDetector ImageOverlay VideoShow Metrics)"
+     ],
+  
+    "parameters": {
+      "_create_stream_":       "1",
+      "_destroy_stream_exit_": "1",
+      "resolution": "640x480", "resolution_mac": "640x360"
+    },
+  
+    "elements": [
+      { "name":   "VideoReadWebcam",
+        "input":  [{"name": "images", "type": "[image]"}],
+        "output": [{"name": "images", "type": "[image]"}],
+        "parameters": {"path": "0"},
+        "deploy": {
+          "local": {"module": "aiko_services.elements.media.webcam_io"}
+        }
+      },
+      { "name":   "ImageResize",
+        "input":  [{"name": "images", "type": "[image]"}],
+        "output": [{"name": "images", "type": "[image]"}],
+        "deploy": {
+          "local": {"module": "aiko_services.elements.media.image_io"}
+        }
+      },
+      { "name":   "LocateAnythingDetector",
+        "input":  [{"name": "images",  "type": "[image]"}],
+        "output": [{"name": "overlay", "type": "[overlay]"}],
+        "deploy": {
+          "local": {"module": "aiko_services.examples.locate_anything.locate_anything"}
+        }
+      },
+      { "name":   "ImageOverlay",
+        "input":  [{"name": "images",  "type": "[image]"},
+                   {"name": "overlay", "type": "[overlay]"}],
+        "output": [{"name": "images",  "type": "[image]"}],
+        "deploy": {
+          "local": {"module": "aiko_services.elements.media.image_io"}
+        }
+      },
+      { "name":   "VideoShow",
+        "input":  [{"name": "images", "type": "[image]"}],
+        "output": [],
+        "parameters": {"position": "1280:0", "title": "Locate Anything detection"},
+        "deploy": {
+          "local": {"module": "aiko_services.elements.media.video_io"}
+        }
+      },
+      { "name":   "Metrics",
+        "#": "Provides Pipeline and PipelineElement timing information",
+        "input":  [],
+        "output": [{"name": "overlay", "type": "[overlay]"}],
+        "deploy": {
+          "local": {"module": "aiko_services.elements.observe.elements"}
+        }
+      }
+    ]
+  }
+  

--- a/src/aiko_services/examples/locate_anything/locate_anything_pipeline_3.json
+++ b/src/aiko_services/examples/locate_anything/locate_anything_pipeline_3.json
@@ -1,0 +1,59 @@
+{
+  "#": "Adapted from examples/yolo/yoloe_pipeline_3.json",
+  "version": 0,
+  "name":    "p_locate_anything",
+  "runtime": "python",
+
+  "graph": [ "(VideoReadFile LocateAnythingDetector ImageOverlay VideoWriteFile)" ],
+
+  "parameters": {
+    "_create_stream_":       "1",
+    "_destroy_stream_exit_": "1"
+  },
+
+  "elements": [
+    { "name":   "VideoReadFile",
+      "parameters": {
+        "data_sources": "(file:data_in/things.mp4)",
+        "data_batch_size": 1
+      },
+      "input":  [{"name": "images", "type": "[image]"}],
+      "output": [{"name": "images", "type": "[image]"}],
+      "deploy": {
+        "local": {"module": "aiko_services.elements.media.video_io"}
+      }
+    },
+    { "name":   "LocateAnythingDetector",
+      "parameters": {
+        "model": "nvidia/LocateAnything-3B",
+        "names": "(apple ball banana cat dog fork glasses knife spoon lightbulb mug person)"
+      },
+      "input":  [{"name": "images",  "type": "[image]"}],
+      "output": [{"name": "overlay", "type": "[overlay]"}],
+      "deploy": {
+        "local": {"module": "aiko_services.examples.locate_anything.locate_anything"}
+      }
+    },
+    { "name":   "ImageOverlay",
+      "input":  [{"name": "images",  "type": "[image]"},
+                 {"name": "overlay", "type": "[overlay]"}],
+      "output": [{"name": "images",  "type": "[image]"}],
+      "deploy": {
+        "local": {"module": "aiko_services.elements.media.image_io"}
+      }
+    },
+    { "name":   "VideoWriteFile",
+      "parameters": {
+        "data_targets": "(file:data_out/things.mp4)",
+        "format": "MP4V",
+        "frame_rate": 10.0,
+        "resolution": "640x360"
+      },
+      "input":  [{"name": "images", "type": "[image]"}],
+      "output": [],
+      "deploy": {
+        "local": {"module": "aiko_services.elements.media.video_io"}
+      }
+    }
+  ]
+}

--- a/src/aiko_services/examples/locate_anything/stubs/decord/__init__.py
+++ b/src/aiko_services/examples/locate_anything/stubs/decord/__init__.py
@@ -1,0 +1,15 @@
+"""Minimal decord stub for image-only LocateAnything inference.
+
+The Hugging Face processor imports decord at module load time. Real decord has no
+PyPI wheel on macOS; this stub is added to sys.path by locate_anything.py.
+"""
+
+
+class VideoReader:
+    def __init__(self, *args, **kwargs):
+        raise ImportError(
+            "decord is not installed; video input is not supported in this environment")
+
+    def get_batch(self, *args, **kwargs):
+        raise ImportError(
+            "decord is not installed; video input is not supported in this environment")


### PR DESCRIPTION
# Summary
Adds a new `examples/locate_anything/` example, modeled after the existing YOLO pipelines, that wraps NVIDIA's LocateAnything model as an aiko `PipelineElement`.

- `LocateAnythingDetector` adapted from `YoloDetector` in `examples/yolo/yolo.py`; implements the `object_detector:0` protocol, parses model output into overlay rectangles, and supports configurable model and names parameters
- `locate_anything_pipeline_0.json`: live webcam pipeline (adapted from `yolo_pipeline_0.json`): webcam → resize → detect → overlay → display + metrics
- `locate_anything_pipeline_3.json`: offline file pipeline (adapted from `yoloe_pipeline_3.json`): read video → detect → overlay → write output
`locate_anything` optional dependency extra in `pyproject.toml` for torch/transformers and related inference deps
- `stubs/decord/`: minimal import stub so transformers loads on macOS without a native decord wheel
- Pillow version constraints relaxed for Python 3.14+

## Setup notes
`locateanything_worker` is not on PyPI. Users must add the Embodied repo (install from https://github.com/NVlabs/Eagle/blob/main/Embodied/locateanything_worker.py) to `PYTHONPATH`:

```
pip install -e ".[locate_anything]"
export PYTHONPATH=$PYTHONPATH:path/to/eagle/Embodied
```

Pipeline 3 expects `data_in/things.mp4` (same layout as `yoloe_pipeline_3.json`); a sample video is not included in this PR, consistent with the YOLO example.

# Test plan

- `pip install -e ".[locate_anything]"` succeeds on target Python version(s)
- With Embodied on `PYTHONPATH`, run webcam pipeline from `examples/locate_anything/`:
```
aiko_pipeline create locate_anything_pipeline_0.json -s 1
```
- Verify bounding boxes render in the "Locate Anything detection" window
- Place a test video at `data_in/things.mp4` and run:
```
aiko_pipeline create locate_anything_pipeline_3.json -s 1
```
- Confirm annotated output is written to `data_out/things.mp4`
- Confirm example loads on macOS without installing decord (stub path injection)
- Confirm base `aiko_services` install still works without the `[locate_anything]` extra
