### PR TITLE
fix: Allow VideoSample to use a sample_rate of 0

### DIFF
--- a/src/aiko_services/elements/media/video_io.py
+++ b/src/aiko_services/elements/media/video_io.py
@@ -229,7 +229,7 @@ class VideoSample(aiko.PipelineElement):
 
     def process_frame(self, stream, images) -> Tuple[aiko.StreamEvent, dict]:
         sample_rate, _ = self.get_parameter("sample_rate", 1)
-        if stream.frame_id % sample_rate:
+        if not sample_rate or stream.frame_id % sample_rate:
             self.logger.debug(f"{self.my_id()}: frame dropped")
             return aiko.StreamEvent.DROP_FRAME, {}
         else:

--- a/src/aiko_services/tests/unit/test_media.py
+++ b/src/aiko_services/tests/unit/test_media.py
@@ -1,0 +1,55 @@
+# Usage
+# ~~~~~
+# pytest [-s] unit/test_media.py
+# pytest [-s] unit/test_media.py::test_VideoSample
+
+from typing import Tuple
+
+from PIL import Image
+
+import aiko_services as aiko
+from aiko_services.tests.unit import do_create_pipeline
+
+PIPELINE_DEFINITION = """{
+  "version": 0, "name": "p_test", "runtime": "python",
+  "graph": ["(GenerateImages VideoSample)"],
+  "elements": [
+    { "name":   "GenerateImages",
+      "parameters": {"data_sources": "(file://__TEMP_FILE__)"},
+      "input":  [],
+      "output": [{"name": "images", "type": "[image]"}],
+      "deploy": {
+        "local": {"module": "aiko_services.tests.unit.test_media"}
+      }
+    },
+    { "name":   "VideoSample",
+      "input":  [{"name": "images", "type": "[image]"}],
+      "output": [{"name": "images", "type": "[image]"}],
+      "parameters": {"sample_rate": 0},
+      "deploy": {
+        "local": {"module": "aiko_services.elements.media.video_io"}
+      }
+    }
+  ]
+}
+"""
+
+
+class GenerateImages(aiko.DataSource):  # PipelineElement
+    def __init__(self, context: aiko.ContextPipelineElement):
+        self.image = Image.new("RGB", (320, 240), "black")
+        context.set_protocol("generate_images:0")
+        context.call_init(self, "PipelineElement", context)
+
+    def process_frame(self, stream) -> Tuple[aiko.StreamEvent, dict]:
+        aiko.process.terminate()
+        return aiko.StreamEvent.OKAY, {"images": [self.image]}
+
+
+def test_VideoSample(capsys, tmp_path):
+    # NOTE(nic): This is here because I couldn't figure out how to avoid setting the `data_sources` parameter,
+    #  nor could I figure out how to set it to a null input.  Throw this down the stairs if a better way exists.
+    d = tmp_path / "video.mp4"
+    d.touch()
+    do_create_pipeline(PIPELINE_DEFINITION.replace("__TEMP_FILE__", str(d)))
+    assert "ZeroDivisionError" not in capsys.readouterr().out


### PR DESCRIPTION
If the parameter is set to `0`, act as a "frame sink" and drop all frames, rather than trying to divide by zero

Relates: Issue #62