### PR TITLE
test: explicitly set pytest paths for collecting tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,5 +108,10 @@ exclude = [
 [tool.hatch.envs.default]
 pytest = "^8.0"
 
+[tool.pytest.ini_options]
+testpaths = [
+    "src/aiko_services/tests"
+]
+
 [tool.hatch.envs.default.scripts]
-test = "pytest {args:tests}"
+test = "pytest {args}"


### PR DESCRIPTION
This should make running unit tests slightly easier

Fixes: Issue #69