### PR TITLE
test: add ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,14 +43,16 @@ dependencies = [
     "Pillow~=10.4.0",
     "psutil~=6.0.0",
     "pyperclip~=1.9.0",
-    "pytest~=8.3.4",
     "pyzmq~=26.2.0",
     "requests~=2.32.3",
     "transitions~=0.9.2",
     "wrapt~=1.16.0"
 ]
 
-# [project.optional-dependencies]
+[project.optional-dependencies]
+test = [
+    "pytest",
+]
 # opencv-python = ["opencv-python~=4.10.0.84"]
 # opencv-contrib-python = ["opencv-contrib-python~=4.10.0.84"]
 # linux = ["PyAudio~=0.2.14"]
@@ -106,6 +108,7 @@ exclude = [
 ]
 
 [tool.hatch.envs.default]
+features = ["test"]
 pytest = "^8.0"
 
 [tool.hatch.envs.default.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
 [project.optional-dependencies]
 test = [
     "pytest",
+    "ruff"
 ]
 # opencv-python = ["opencv-python~=4.10.0.84"]
 # opencv-contrib-python = ["opencv-contrib-python~=4.10.0.84"]
@@ -108,8 +109,50 @@ exclude = [
 ]
 
 [tool.hatch.envs.default]
+path = ".hatch"
 features = ["test"]
-pytest = "^8.0"
 
 [tool.hatch.envs.default.scripts]
-test = "pytest {args:tests}"
+test = [
+    "- check", # TODO(nic): remove leading `-` and make this enforcing rather than advisory
+    "pytest {args:tests}",
+]
+check = [
+    "ruff format --check src/aiko_services",
+    "ruff check src/aiko_services"
+]
+format = [
+    "ruff format src/aiko_services",
+    "ruff check --select I,F401 --fix-only --show-fixes src/aiko_services"
+]
+
+[tool.ruff]
+cache-dir = "~/.cache/ruff"
+line-length = 120
+output-format = "full"
+target-version = "py39"
+exclude = [
+    ".git",
+    ".hatch",
+    "__pycache__",
+]
+
+[tool.ruff.lint]
+select = ["B", "C9", "D", "E", "F", "I", "S", "W"]
+ignore = [
+    "B905", # Allow `zip()` without an explicit `strict=` parameter
+    "D10", # ignore missing docstrings (for now)
+    "D202", # No blank lines allowed after function docstring
+    "D203", # Allow One Blank Line Before Class
+    "D213", # Allow "Multi-line docstring summary should start at the second line"
+    "D418", # Allow @overload funcs to contain docstrings
+    "F403", # Allow star imports (for now)
+    "F405", # Allow undefined locals when star imports used (for now)
+    "S101", # Allow use of `assert`, pytest doesn't do much without it
+    "S110", # Allow try/except/pass
+]
+mccabe.max-complexity = 13
+
+[tool.ruff.lint.per-file-ignores]
+# Ignore `F401` (unused imports) in all `__init__.py` files
+"__init__.py" = ["F401"]


### PR DESCRIPTION
Adds a `hatch run check` script to verify that all files in the project are formatted according to best practices, i.e., PEP8, cyclomatic complexity, etc.

Adds the `check` script to the commands that `hatch run test` runs, so that improperly formatted code can fail gate checks

Adds a `hatch run format` script to automagically reformat all files in the project according to best practices

Configures the project with some sensible default values

chore: break test dependencies out from main package dependencies

We don't want to install pytest and friends in a production deployment, it just wastes space.