### PR TITLE
chore: remove Python 2 import fallbacks

### DIFF
--- a/documentation/elements/gstreamer/video_file_writer.md
+++ b/documentation/elements/gstreamer/video_file_writer.md
@@ -120,8 +120,6 @@ of the constructor arguments (see Current limitations and roadmap).
   `queue.get()`. After EOS it keeps consuming (an image after EOS would
   be pushed into a stopped stream). Process exit while frames are
   buffered can truncate the file.
-- The Python 2 `Queue` import fallback (`sys.version_info`) is dead
-  code in a Python 3 codebase.
 
 ### CRC card
 

--- a/src/aiko_services/elements/gstreamer/video_file_writer.py
+++ b/src/aiko_services/elements/gstreamer/video_file_writer.py
@@ -5,10 +5,7 @@
 import sys
 from threading import Thread
 
-if sys.version_info >= (3,0):
-  from queue import Queue, Empty
-else:
-  from Queue import Queue, Empty
+from queue import Queue, Empty
 
 from aiko_services.elements.gstreamer import *
 

--- a/src/aiko_services/elements/gstreamer/video_reader.py
+++ b/src/aiko_services/elements/gstreamer/video_reader.py
@@ -14,10 +14,7 @@ import sys
 from threading import Thread
 import time
 
-if sys.version_info >= (3,0):
-  from queue import Queue, Empty
-else:
-  from Queue import Queue, Empty
+from queue import Queue, Empty
 
 from aiko_services.elements.gstreamer import *
 

--- a/src/aiko_services/elements/gstreamer/video_stream_writer.py
+++ b/src/aiko_services/elements/gstreamer/video_stream_writer.py
@@ -10,10 +10,7 @@ import sys
 import time
 from threading import Thread
 
-if sys.version_info >= (3,0):
-  from queue import Queue, Empty
-else:
-  from Queue import Queue, Empty
+from queue import Queue, Empty
 
 from aiko_services.elements.gstreamer import *
 


### PR DESCRIPTION
Python 2.x is not supported, remove dead code