### PR TITLE
docs(hyperspace): add a runnable chat_space example

### DIFF
--- a/src/aiko_services/examples/hyperspace_chat_space/ReadMe.md
+++ b/src/aiko_services/examples/hyperspace_chat_space/ReadMe.md
@@ -1,0 +1,83 @@
+# HyperSpace example: chat_space
+
+Builds the HyperSpace that [Aiko Chat](https://github.com/geekscape/aiko_chat)
+uses, from an empty directory, with one command per concept.
+
+`ChatServer` creates this HyperSpace by name and reads its channel list
+out of the graph ...
+
+```python
+self.hyperspace = aiko.HyperSpaceImpl.create_hyperspace("chat_space")
+self.channels   = self.hyperspace.share["entries"]["channels"]
+```
+
+## Run it
+
+Every command uses `-b` (`--bootstrap`), which operates directly on the
+file-system. No MQTT broker, Registrar or Storage Service is required.
+
+```
+$ ./build_chat_space.sh
+```
+
+The result ...
+
+```
+--- The graph: 6 names ---
+agents/
+  nickba
+channels/
+  general
+  nickba
+  robotics
+
+--- The store: 5 Entries, because nickba is linked twice ---
+00/00/00/00/00/00  channels
+00/00/00/00/00/01  agents
+00/00/00/00/00/02  general
+00/00/00/00/00/03  robotics
+00/00/00/00/00/04  nickba
+```
+
+## What the two listings show
+
+`list` walks the symbolic links, so it reports the graph: six names.
+`dump` reads `_hyperspace_/tracked_paths`, so it reports the store: five
+Entries. The difference is `nickba`, which is linked from both `agents`
+and `channels`.
+
+That is the property which lets one Service belong to several Categories
+at once. `link` creates one symbolic link. It mints no UID and copies no
+content, so a second membership costs a link and nothing else.
+
+On disk ...
+
+| Concept    | File-system            |
+|------------|------------------------|
+| Category   | directory              |
+| Dependency | file                   |
+| Entry name | symbolic link to a UID |
+| The store  | `_hyperspace_/`        |
+| The index  | `tracked_paths`        |
+
+## Remove and the reference count
+
+Remove one of two links and the Entry survives, because the other link
+still reaches it. Remove the last link and Storage reclaims the Entry
+and its line in `tracked_paths`.
+
+```
+$ cd chat_space
+$ aiko_storage_file remove channels/nickba -b   # agents/nickba survives
+$ aiko_storage_file remove agents/nickba   -b   # the Entry is reclaimed
+```
+
+## To Do
+
+- Persist each Dependency's ServiceFilter. Storage writes a 0-byte file
+  for a Dependency, so protocol, transport, owner and tags do not survive
+  a restart, and `list` reports `*` for every one of them.
+- `link` into a Dependency raises out of `click`. An Entry path cannot
+  descend through a leaf, and the command must report that.
+- Write `tracked_paths` with one terminator. `add` and `create` end the
+  file with a newline. `remove` rewrites it without one.

--- a/src/aiko_services/examples/hyperspace_chat_space/build_chat_space.sh
+++ b/src/aiko_services/examples/hyperspace_chat_space/build_chat_space.sh
@@ -1,0 +1,63 @@
+#!/bin/zsh
+#
+# Build the "chat_space" HyperSpace used by Aiko Chat, from an empty directory.
+#
+# Every command runs in bootstrap mode (-b), directly against the file-system,
+# so no MQTT broker, Registrar or Storage Service is required.
+#
+# Usage
+# ~~~~~
+#   ./build_chat_space.sh [TARGET_DIRECTORY]    # default: ./chat_space
+#
+# The result is the Category structure that ChatServer expects, where
+# "chat_server.py" reads its channel list:
+#
+#     self.hyperspace = aiko.HyperSpaceImpl.create_hyperspace("chat_space")
+#     self.channels   = self.hyperspace.share["entries"]["channels"]
+#
+# To Do
+# ~~~~~
+# - Persist each Dependency's ServiceFilter. Storage writes a 0-byte file for
+#   a Dependency, so protocol, transport, owner and tags do not survive a
+#   restart and "list" reports "*" for every one of them.
+# - "link" into a Dependency raises out of click, rather than reporting that
+#   an Entry path cannot descend through a leaf.
+
+set -e
+
+TARGET=${1:-chat_space}
+
+# Predictable incrementing UIDs, so a second run is comparable with the first.
+export STORAGE_RANDOM_UID=False
+
+mkdir -p $TARGET
+cd $TARGET
+
+# Create "_hyperspace_/" (the content-addressed store) and the ".root"
+# symbolic link, which every Entry resolves its own links through.
+aiko_storage_file initialize
+
+# Categories are directories. Each one is minted under a UID in the store,
+# then linked into the graph under its human-readable name.
+aiko_storage_file create channels -b
+aiko_storage_file create agents   -b
+
+# Dependencies are files. Each channel is a Service reference, and a channel
+# name is also the MQTT topic suffix ChatREPL subscribes to:
+#   f"{chat_server_topic_path}/{channel}"
+aiko_storage_file add channels/general  -b
+aiko_storage_file add channels/robotics -b
+
+# An Agent, in its own Category.
+aiko_storage_file add agents/nickba -b
+
+# The same Entry, linked into a second Category. This mints no UID and copies
+# no content: one Entry, two paths, which is what makes the structure a graph
+# rather than a tree.
+aiko_storage_file link channels/nickba agents/nickba -b
+
+echo "\n--- The graph: 6 names ---"
+aiko_storage_file list -r -b
+
+echo "\n--- The store: 5 Entries, because nickba is linked twice ---"
+aiko_storage_file dump -b


### PR DESCRIPTION
## Why

`examples/hyperspace/ReadMe.md` documents an `ls / mkdir / ln / mk / rm` command
set. The shipped CLI is `add / create / destroy / dump / exit / list / remove /
run / update`, so the example can't be followed as written.

This adds a second example that runs, rather than editing the existing one —
whether to correct or retire that one felt like your call, not something to
bundle into this.

## What

`examples/hyperspace_chat_space/` — a script and a ReadMe that build the
HyperSpace `ChatServer` creates by name:

```python
self.hyperspace = aiko.HyperSpaceImpl.create_hyperspace("chat_space")
self.channels   = self.hyperspace.share["entries"]["channels"]
```

One command per concept, entirely in bootstrap mode (`-b`), so it needs no
broker, Registrar or Storage Service.

The example is built around the difference between the two listings:

- `list` walks the symbolic links and reports **six names**
- `dump` reads `tracked_paths` and reports **five Entries**

The difference is one Entry linked from two Categories — which is the property
that lets a Service belong to several Categories at once. `link` creates one
symbolic link, mints no UID and copies no content.

## Verification

Every command was run and its effect on the file-system captured by snapshotting
the tree before and after. Nothing in the ReadMe is described from reading the
source. With `STORAGE_RANDOM_UID=False` the UIDs count up, so a second run is
comparable with the first.

## Defects found while writing it

Filed separately so this PR stays reviewable. The first four are summarised
under `To Do` in both files:

| | Issue |
|---|---|
| 1 | #78 — a Dependency's ServiceFilter is never persisted (0-byte file) |
| 2 | #79 — `link` into a Dependency raises `NotADirectoryError` out of `click` |
| 3 | #80 — `tracked_paths` written with two different terminators |
| 4 | #81 — a failed `add` leaks an untracked 0-byte file into the store |
| 5 | #82 — pipeline element `type` is declared but never enforced |
| 6 | #83 — cycles are silently creatable; `list -r` truncates via kernel ELOOP |

#82 and #83 are design questions rather than slips, and are worth a decision
before anyone writes code against them.

Happy to fold any of the fixes into this PR instead if you'd rather they travel
together.

🤖 (generated) 🧑‍💻 (reviewed)