### PR TITLE
fix(discovery): a Service proxy stops sending once its Service is removed

### DIFF
--- a/src/aiko_services/main/__init__.py
+++ b/src/aiko_services/main/__init__.py
@@ -67,6 +67,7 @@ from .actor import (
 from .discovery import (
     ServiceDiscovery, ActorDiscovery,
     PipelineElementDiscovery, PipelineDiscovery,
+    ServiceUnavailable,
     do_command, do_discovery, do_request, get_service_proxy
 )
 

--- a/src/aiko_services/main/discovery.py
+++ b/src/aiko_services/main/discovery.py
@@ -68,6 +68,7 @@
 from abc import abstractmethod
 import click
 from inspect import getmembers, isfunction
+import weakref
 
 from aiko_services.main import *
 from aiko_services.main.utilities import *
@@ -75,6 +76,7 @@ from aiko_services.main.utilities import *
 __all__ = [
     "ServiceDiscovery", "ActorDiscovery",
     "PipelineElementDiscovery", "PipelineDiscovery",
+    "ServiceUnavailable",
     "do_command", "do_discovery", "do_request", "get_service_proxy"
 ]
 
@@ -141,6 +143,29 @@ class PipelineDiscovery(PipelineElementDiscovery):
 # def delete_actor_mqtt(actor):
 #   actor.terminate()
 
+class ServiceUnavailable(RuntimeError):
+    """A remote Service proxy was used after discovery removed the Service"""
+
+# Proxies made by do_discovery(), keyed by Service topic path.  Discovery
+# already learns when a Service goes away.  Without this the proxy does not
+# find out, so its publishes go to a topic with no subscriber and the caller
+# sees success.
+
+_service_proxies = {}   # key: Service topic path, value: WeakSet of proxies
+
+def _track_service_proxy(service_topic_path, service_proxy):
+    service_proxies = _service_proxies.get(service_topic_path)
+    if service_proxies is None:
+        service_proxies = weakref.WeakSet()
+        _service_proxies[service_topic_path] = service_proxies
+    service_proxies.add(service_proxy)
+
+def _remove_service_proxies(service_topic_path):
+    service_proxies = _service_proxies.pop(service_topic_path, None)
+    if service_proxies:
+        for service_proxy in service_proxies:
+            service_proxy._available = False
+
 def _get_public_method_names(protocol_class):
     if isinstance(protocol_class, str):
         raise ValueError(
@@ -156,25 +181,37 @@ def _get_public_method_names(protocol_class):
 
 def _make_service_proxy(target_topic_in, public_method_names):
     class ServiceRemoteProxy():
+        def is_available(self):
+            return self._available
+
         def is_local(self):
             return False
 
     def _proxy_send_message(method_name):
         def closure(*args, **kwargs):
+            if not service_remote_proxy._available:
+                raise ServiceUnavailable(
+                    f'Service "{target_topic_in}" was removed: '
+                    f'"{method_name}()" not sent')
             arguments = args if not kwargs else [args[0], kwargs]
             payload = generate(method_name, arguments)
             aiko.message.publish(target_topic_in, payload)
         return closure
 
     service_remote_proxy = ServiceRemoteProxy()
+    service_remote_proxy._available = True
     for method_name in public_method_names:
         setattr(service_remote_proxy,
             method_name, _proxy_send_message(method_name))
     return service_remote_proxy
 
-def get_service_proxy(service_topic, protocol_class):
+def get_service_proxy(service_topic, protocol_class,
+    service_topic_path=None):
+
     public_methods = _get_public_method_names(protocol_class)
     service_proxy = _make_service_proxy(service_topic, public_methods)
+    if service_topic_path:
+        _track_service_proxy(service_topic_path, service_proxy)
     return service_proxy
 
 # --------------------------------------------------------------------------- #
@@ -186,10 +223,12 @@ def do_discovery(
     def service_discovery_handler(command, service_details):
         if command == "add":
             topic_path = f"{service_details[0]}/in"
-            service = get_service_proxy(topic_path, service_interface)
+            service = get_service_proxy(topic_path, service_interface,
+                service_topic_path=service_details[0])
             if discovery_add_handler:
                 discovery_add_handler(service_details, service)
         elif command == "remove":
+            _remove_service_proxies(service_details[0])
             if discovery_remove_handler:
                 discovery_remove_handler(service_details)
 

--- a/src/aiko_services/tests/unit/test_service_proxy.py
+++ b/src/aiko_services/tests/unit/test_service_proxy.py
@@ -1,0 +1,113 @@
+# Usage
+# ~~~~~
+# pytest [-s] unit/test_service_proxy.py
+#
+# Covers the remote Service proxy made by get_service_proxy():
+# - a proxy publishes to the Service "topic_in" while the Service is present
+# - a proxy raises ServiceUnavailable once discovery removes that Service,
+#   rather than publishing to a topic with no subscriber and reporting success
+# - only the removed Service's proxies are affected
+# - a proxy obtained without a Service topic path keeps the old behaviour,
+#   because nothing tells it when the Service goes away
+# - is_available() reports the same state the proxy acts on
+
+from abc import abstractmethod
+
+import pytest
+
+import aiko_services as aiko
+from aiko_services.main import discovery
+
+_TOPIC_A = "aiko/host/1000/1"
+_TOPIC_B = "aiko/host/2000/1"
+
+
+class _Target(aiko.Actor):
+    aiko.Interface.default("_Target", None)
+
+    @abstractmethod
+    def ping(self, value):
+        pass
+
+
+@pytest.fixture
+def published(monkeypatch):
+    records = []
+
+    class _Message:
+        def publish(self, topic, payload, retain=False):
+            records.append((topic, payload))
+
+    monkeypatch.setattr(aiko.aiko, "message", _Message())
+    monkeypatch.setattr(discovery, "_service_proxies", {})
+    return records
+
+
+def _proxy(topic_path):
+    return aiko.get_service_proxy(
+        f"{topic_path}/in", _Target, service_topic_path=topic_path)
+
+
+def test_proxy_publishes_while_service_is_present(published):
+    _proxy(_TOPIC_A).ping(1)
+    assert published == [(f"{_TOPIC_A}/in", "(ping 1)")]
+
+
+def test_proxy_raises_after_its_service_is_removed(published):
+    proxy = _proxy(_TOPIC_A)
+    proxy.ping(1)
+    assert len(published) == 1
+
+    discovery._remove_service_proxies(_TOPIC_A)
+
+    with pytest.raises(aiko.ServiceUnavailable) as error:
+        proxy.ping(2)
+    assert "ping()" in str(error.value)
+    assert _TOPIC_A in str(error.value)
+
+    # The point of the change: nothing reached a topic with no subscriber
+    assert len(published) == 1
+
+
+def test_removing_one_service_leaves_other_proxies_alone(published):
+    proxy_a = _proxy(_TOPIC_A)
+    proxy_b = _proxy(_TOPIC_B)
+
+    discovery._remove_service_proxies(_TOPIC_A)
+
+    with pytest.raises(aiko.ServiceUnavailable):
+        proxy_a.ping(1)
+    proxy_b.ping(2)
+    assert published == [(f"{_TOPIC_B}/in", "(ping 2)")]
+
+
+def test_every_proxy_for_one_service_is_removed(published):
+    proxy_0 = _proxy(_TOPIC_A)
+    proxy_1 = _proxy(_TOPIC_A)
+
+    discovery._remove_service_proxies(_TOPIC_A)
+
+    for proxy in (proxy_0, proxy_1):
+        with pytest.raises(aiko.ServiceUnavailable):
+            proxy.ping(1)
+
+
+def test_untracked_proxy_keeps_the_previous_behaviour(published):
+    # get_service_proxy() without a Service topic path, as chat_server.py and
+    # ExampleImpl.request() use it for a response topic.  Nothing reports when
+    # that topic goes away, so the proxy cannot know: it must still publish.
+    proxy = aiko.get_service_proxy(f"{_TOPIC_A}/in", _Target)
+    discovery._remove_service_proxies(_TOPIC_A)
+    proxy.ping(1)
+    assert published == [(f"{_TOPIC_A}/in", "(ping 1)")]
+
+
+def test_is_available_matches_what_the_proxy_does(published):
+    proxy = _proxy(_TOPIC_A)
+    assert proxy.is_available() is True
+
+    discovery._remove_service_proxies(_TOPIC_A)
+
+    assert proxy.is_available() is False
+    with pytest.raises(aiko.ServiceUnavailable):
+        proxy.ping(1)


### PR DESCRIPTION
**Draft** — the mechanism works and is tested, but there are two calls I'd
want from you before this is more than a proposal. Both are at the bottom.

## The behaviour today

A proxy from `get_service_proxy()` publishes to the target's `topic_in`. When
that Service goes away the publishes land on a topic with no subscriber, MQTT
discards them, and the caller sees success.

Measured against a live broker, Registrar and two Actors — peer killed at t=5.9:

```
[observer t= 5.896] DISCOVERY remove: aiko/…/63275/1
[observer t= 6.164] proxy.ping(6)  returned normally — no error raised
[observer t= 7.163] proxy.ping(7)  returned normally — no error raised
…14 calls over 8 seconds, every one reported success
```

## Why this one is cheap

The sharp part isn't that there's no signal. **The signal was already in the
process.** That same process ran its discovery `remove` handler at t=5.896 and
then kept calling the proxy at t=6, 7, 8…

`do_discovery()` learns when a Service is removed *and* is what created the
proxy. The two were simply never connected. So this is a wiring change, not a
new protocol — no wire format change, no new message, no dependency.

## After

Same rig, same scenario:

```
[observer t= 5.896] DISCOVERY remove: aiko/…/63275/1
[observer t= 6.164] proxy.ping(6) RAISED ServiceUnavailable:
                    Service "aiko/…/63275/1/in" was removed: "ping()" not sent
```

## What changed

- proxies made through `do_discovery()` are tracked by Service topic path in a
  `WeakSet`, so they don't keep dead proxies alive
- the `remove` branch marks them unavailable **before** calling the
  application's remove handler, so a handler that uses the proxy also sees it
- calling a removed proxy raises `ServiceUnavailable` and sends nothing
- `is_available()` reports the same state the proxy acts on
- `get_service_proxy(service_topic, protocol_class)` keeps its signature; the
  Service topic path is a new optional third argument

**Unchanged:** proxies built by calling `get_service_proxy()` directly, without
a Service topic path. Nothing reports when their topic goes away, so they
cannot know. `chat_server.py` and `ExampleImpl.request()` build a response-topic
proxy that way and must keep publishing. There's a test pinning that.

## Tests

`tests/unit/test_service_proxy.py`, 6 cases: publishes while present, raises
after removal, other Services' proxies unaffected, every proxy for one Service
removed, untracked proxies keep the old behaviour, `is_available()` agrees with
what the proxy does. Full unit suite: 31 passed.

Note on evidence: the tests pin the *new* behaviour. The RED evidence for the
old behaviour is the live measurement above, not a test — a unit test for it
would have to assert that a dead proxy silently succeeds, which is the thing
being removed.

## Two calls I'd like from you

1. **Raise, or return a status?** Raising is right if silence is the defect, but
   it changes behaviour for existing callers. There is no per-handler exception
   isolation in the event loop yet (`process.py` To Do notes this), so a raise
   inside a discovery-driven handler could take the process down where it
   previously continued. I think that is the correct trade — a dead peer should
   not be survivable-by-accident — but it is your call, and `is_available()`
   exists so callers can test instead of catch.

2. **Should `do_command()` / `do_request()` handle it?** Both build proxies via
   `do_discovery()`, so both are now in scope for the raise. They currently have
   no error path. I have deliberately not touched them.

Context: found while measuring Actor death for the Dart port. Related to
#78–#83. Two other findings from the same session that are **not** addressed
here and may deserve their own issues — liveness detection depends entirely on
the Registrar (kill it and no peer ever learns of any death), and a frozen
Actor is undetectable for ~86s (1.5 × MQTT keepalive).

🤖 (generated) 🧑‍💻 (reviewed)