### PR TITLE
fix: storage_file_add handles duplicate entries gracefully

### DIFF
--- a/src/aiko_services/main/storage/storage_file.py
+++ b/src/aiko_services/main/storage/storage_file.py
@@ -151,12 +151,12 @@ class StorageFileImpl(Storage):
     def add(self, dependency_name, dependency=None):
         path = Path(self._create_unique_path())
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.touch()
         try:
             Path(dependency_name).symlink_to(f"{_ROOT_FILENAME}/{path}")
-            self._track_path(path)
+            path.touch()
         except FileExistsError:
             print(f'Error: "{dependency_name}" already exists', file=sys.stderr)
+        self._track_path(path)
 
     # Create category (directory)
     #


### PR DESCRIPTION
Create the symbolic link before the link target when adding dependency files; this way if the link already exists, it won't do unnecesary work, so no cleanup is required

Also removes the call to _track_path from the try/except block; that code cannot raise FileExistsError, so having it in there is pointless

Fixes: Issue #81