### PR TITLE
Documentation: quick start guide, tutorials ladder, ReadMe navigation

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -3,7 +3,7 @@
 <pre style="font-family: Monaco, monospace; font-size: 14px; line-height: 1.5;
     color: #39ff14; background-color: #000000; padding: 20px;
     border-radius: 5px;">
-(aiko services (loop
+(aiko_services (loop
      (perceive   :self :reality)
      (understand :self :reality)
      (transform  :self :reality)))
@@ -39,10 +39,13 @@ the [Aiko Dashboard](src/aiko_services/main/dashboard.py)
 
 # Documentation
 
-- [Design overview](documentation/concepts/design_overview.md)
+- [Quick start guide](documentation/quick_start_guide.md) 🚀
+- [Tutorials](documentation/tutorials/ReadMe.md)
 - [Concepts guide](documentation/concepts/ReadMe.md) 👀
+- [Design overview](documentation/concepts/design_overview.md)
 - [Pipeline](/documentation/concepts/pipeline.md) and [PipelineElements guide](documentation/elements/ReadMe.md)
 - [Examples reference](documentation/examples/ReadMe.md)
+- [Constitution for A.I Coding Assistants](constitution/ReadMe.md) 🤖
 - [Release notes](documentation/release_notes.md)
 
 Uses the [Open Knowledge Format](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing) ... and so the documentation is immediately useable by your favorite A.I coding assistant 🤖
@@ -115,7 +118,7 @@ HATCH_INDEX_USER=__token__ HATCH_INDEX_AUTH=pypi-YOUR_API_TOKEN  \
   hatch publish dist/   # Publish Aiko Services package to PyPI
 ```
 
-# Quick start
+# Getting started
 
 After [**installing**](#Installation) *(above)*, choose whether to use a public MQTT server ... or to install and run your own MQTT server
 

--- a/constitution/ReadMe.md
+++ b/constitution/ReadMe.md
@@ -110,8 +110,9 @@ gate that earns every declaration.
 
 - [ADR registry](adr/ReadMe.md) — Architectural Decision Records
   (`ADR-NNN_ClearName.md`). The registry owns the numbers.
-- [Diagrams](diagrams/) — architecture overview, architecture detail and
-  HyperSpace structure (standalone HTML).
+- [Diagrams](diagrams/ReadMe.md) — architecture overview, architecture
+  detail and HyperSpace structure, with rendered-view links (GitHub shows
+  raw HTML source, so use the View links there).
 - [Public journal](log.md) — the dated journal of changes to this tree.
   Every substantive change appends an entry.
 - [Documentation reading guide](../documentation/ReadMe.md) — the

--- a/constitution/diagrams/ReadMe.md
+++ b/constitution/diagrams/ReadMe.md
@@ -1,0 +1,33 @@
+---
+title: Aiko Services architecture diagrams — index
+description: The architecture diagrams as standalone HTML — with rendered
+  view links, because GitHub shows raw HTML source rather than the diagram
+type: index
+audience: [architects, developers, ai-coding-agents]
+status: operational
+ste: adapted
+last_updated: 2026-08-31
+---
+
+# Aiko Services architecture diagrams
+
+Each diagram is a standalone HTML file. GitHub shows the HTML source, not
+the rendered diagram — use a **View** link below, or open the file
+locally in any browser.
+
+| Diagram | View (rendered) | Source |
+|---------|-----------------|--------|
+| Architecture overview — one bus, no privileged plane | [View](https://htmlpreview.github.io/?https://github.com/geekscape/aiko_services/blob/master/constitution/diagrams/aiko_services_architecture.html) | [HTML](aiko_services_architecture.html) |
+| Architecture detail — the four layers of v0.6 | [View](https://htmlpreview.github.io/?https://github.com/geekscape/aiko_services/blob/master/constitution/diagrams/aiko_services_architecture_detail.html) | [HTML](aiko_services_architecture_detail.html) |
+| HyperSpace and ProcessManager structure | [View](https://htmlpreview.github.io/?https://github.com/geekscape/aiko_services/blob/master/constitution/diagrams/aiko_services_hyperspace.html) | [HTML](aiko_services_hyperspace.html) |
+
+To view locally instead:
+
+```bash
+git clone https://github.com/geekscape/aiko_services.git
+open aiko_services/constitution/diagrams/aiko_services_architecture.html
+```
+
+(Linux: use `xdg-open`. Windows: use `start`.) The View links use the
+third-party htmlpreview.github.io renderer. If the project enables GitHub
+Pages, these links can change to first-party URLs.

--- a/constitution/log.md
+++ b/constitution/log.md
@@ -6,6 +6,13 @@ Every substantive change appends an entry under its date heading
 This journal begins at the constitution's first public release. The
 pre-publication history is maintained privately.
 
+## 2026-08-31
+
+- **Creation** — [diagrams/ReadMe.md](diagrams/ReadMe.md): index for the
+  three architecture diagrams with rendered-view links, because GitHub
+  shows raw HTML source rather than the diagram output. The Related
+  section of [ReadMe.md](ReadMe.md) now points at it.
+
 ## 2026-08-27
 
 - **Creation** — the constitution goes public. The governance corpus moved

--- a/documentation/quick_start_guide.md
+++ b/documentation/quick_start_guide.md
@@ -1,0 +1,184 @@
+---
+title: Aiko Services — Getting Started (the recipe)
+description: A 15-minute copy-paste recipe from nothing to a running pipeline plus an AI-assistant setup — no programming experience needed
+type: guide
+audience: [application-developers]
+status: operational
+ste: adapted
+last_updated: 2026-08-31
+---
+
+# Aiko Services — Getting Started (the recipe)
+
+Build something real with an AI coding assistant, on a framework that
+keeps the code good even when you are new. Follow the steps in order.
+Each step tells you what you should see. Total time: about 15 minutes.
+
+You need: a computer (Windows, Mac or Linux), its terminal app
+(Windows: **PowerShell** · Mac/Linux: **Terminal**), and an AI coding
+assistant (like Claude Code). You do **not** need to be a programmer.
+
+---
+
+## 1. Check you have Python
+
+Open your terminal. Type this and press Enter:
+
+**Mac / Linux:**
+
+```bash
+python3 --version
+```
+
+**Windows (PowerShell):**
+
+```powershell
+python --version
+```
+
+**You should see:** something like `Python 3.11.6` (any 3.9 or higher is
+fine). If you get "command not found" / "not recognized", install Python
+from python.org first — on Windows, tick **"Add Python to PATH"** in the
+installer — then come back.
+
+## 2. Make a workspace
+
+**Mac / Linux:**
+
+```bash
+mkdir my_app
+cd my_app
+python3 -m venv venv
+source venv/bin/activate
+```
+
+**Windows (PowerShell):**
+
+```powershell
+mkdir my_app
+cd my_app
+python -m venv venv
+venv\Scripts\Activate.ps1
+```
+
+**You should see:** `(venv)` appear at the start of your prompt. That
+means you are in a clean workspace. (Any time you open a new terminal,
+go back into `my_app` and run the activate line again.)
+
+## 3. Install the framework
+
+```bash
+pip install aiko_services
+```
+
+**You should see:** lines ending with `Successfully installed ...`.
+
+## 4. Get the examples
+
+```bash
+git clone https://github.com/geekscape/aiko_services.git framework
+```
+
+**You should see:** a new `framework` folder appear. It holds working
+examples your AI assistant will learn from.
+
+## 5. Run your first pipeline (the "hello world")
+
+```bash
+aiko_pipeline create framework/src/aiko_services/examples/pipeline/pipeline_example.json -s 1 -p limit 10 -p rate 1
+```
+
+**You should see:** lines printing as data flows through a small
+processing pipeline, then it stops. That is the framework working, all in
+one window, nothing else needed. 🎉
+
+If it worked — you are ready to build. If not, see Troubleshooting below.
+
+## 6. Add the rulebook file
+
+This is the important one. Create a file called `Agents.md` in your
+`my_app` folder, containing exactly this (copy-paste, then change the
+first line to describe YOUR app):
+
+```markdown
+# MyApp: Agent instructions
+
+MyApp is built on the Aiko Services framework
+(github.com/geekscape/aiko_services) and follows its Design
+Principles: constitution/p_00_DesignPrinciples.md in that repository.
+
+Rules for every coding session:
+- Read the Design Principles before designing anything. When you make
+  a design decision, say which principle (P-number) guided it.
+- Prefer building a Pipeline of PipelineElements. Reuse existing
+  elements from framework/src/aiko_services/elements/ before writing
+  new ones. Learn from framework/src/aiko_services/examples/pipeline/.
+- Never make a method return a value across the network. Never use
+  async/await with the framework. Never hard-code addresses or topics.
+- Always write "Aiko Services" in full. Name ReadMe files "ReadMe.md".
+```
+
+Then link it for Claude (one command):
+
+**Mac / Linux:**
+
+```bash
+ln -s Agents.md CLAUDE.md
+```
+
+**Windows (PowerShell):**
+
+```powershell
+cmd /c mklink CLAUDE.md Agents.md
+```
+
+(If Windows refuses the link, just copy instead — `copy Agents.md
+CLAUDE.md` — and remember: always edit `Agents.md`, then re-copy.)
+
+**Why this file matters (one sentence):** your AI assistant reads it
+automatically at the start of every session, so it follows the
+framework's rules without you having to know them.
+
+## 7. Start your AI assistant and paste this prompt
+
+> Read Agents.md, then the Aiko Services Design Principles it points to.
+> I want to build: **[describe your idea in one or two sentences]**.
+> Propose a simple Pipeline design first. Which existing elements can
+> we reuse? What (if anything) must we write? Tell me which
+> P-numbers guided the design. Keep it as simple as possible.
+
+Then just talk to it. Ask questions. Ask it to run things and show you.
+
+## 8. Your first change (a good warm-up)
+
+Ask your assistant:
+
+> Copy the example pipeline into our project and change it to process
+> 20 items instead of 10. Run it and show me the output.
+
+**You should see:** your own copy of the pipeline, doing your bidding.
+From here, it is your idea, one small step at a time.
+
+---
+
+## Troubleshooting
+
+| Problem | Fix |
+|---|---|
+| `command not found` / `not recognized`: `aiko_pipeline` | Re-run the activate line from step 2 — you are not in the workspace |
+| `python3` / `python` not found | Install Python from python.org (Windows: tick "Add Python to PATH") |
+| `git` not found | Windows: install from git-scm.com. Mac: run `xcode-select --install`. Linux: `sudo apt install git` |
+| Windows: "running scripts is disabled" when activating | Run `Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser`, answer Y, then activate again |
+| Windows: `mklink` says access denied | Use the copy fallback in step 6 |
+| Something else | Paste the exact error into your AI assistant and ask |
+
+## When you are ready for more
+
+- [**Tutorial: First project**](tutorials/first_project.md) explains
+  everything this recipe skipped — the two ways to start (Pipeline or
+  Actor), and what the Design Principles actually say. More tutorials:
+  [the tutorials index](tutorials/ReadMe.md).
+- When your app should talk to other apps across machines: ask your
+  assistant about "running with a broker, the Registrar and the
+  Dashboard". Your pipeline will not need rewriting — that is a promise the
+  framework's rules keep for you.

--- a/documentation/tutorials/ReadMe.md
+++ b/documentation/tutorials/ReadMe.md
@@ -1,0 +1,38 @@
+---
+title: Aiko Services tutorials — index
+description: The tutorial ladder in three levels — Start (your first
+  project), Create (working with the public constitution) and Advanced
+  (working with a private constitution)
+type: index
+audience: [application-developers, developers, ai-coding-agents]
+status: operational
+ste: adapted
+last_updated: 2026-08-31
+---
+
+# Aiko Services tutorials
+
+Three levels. Read them in order — each level assumes the one before it.
+New to everything? Do the [Quick start guide](../quick_start_guide.md)
+first: from nothing to a running pipeline in 15 minutes.
+
+## Start
+
+| Tutorial | You will learn |
+|----------|----------------|
+| [First project](first_project.md) | Set up a new Aiko Application so that the Constitution steers your AI coding agent. Choose a starting shape (Pipeline or Actor). Use the prompt and the `Agents.md` seed |
+
+## Create
+
+| Tutorial | You will learn |
+|----------|----------------|
+| [Using the public Constitution](using_the_public_constitution.md) | The three lanes of contribution: everyday coding (no ceremony), bumping into a rule, and making a move in the game |
+
+## Advanced
+
+| Tutorial | You will learn |
+|----------|----------------|
+| [Using a private Constitution](using_a_private_constitution.md) | A private downstream repository for future code, docs and law — and the promotion ceremony that makes things public |
+
+Related: the [Constitution index](../../constitution/ReadMe.md) — the
+principles and rules that the tutorials build on.

--- a/documentation/tutorials/first_project.md
+++ b/documentation/tutorials/first_project.md
@@ -1,0 +1,191 @@
+---
+title: Tutorial 0 — Building an Aiko Application on the Constitution
+description: Set up a new Aiko Application so the Constitution steers your AI coding agent — two starting shapes (Pipeline or Actor), the prompt, and the Agents.md seed
+type: guide
+audience: [application-developers, ai-coding-agents]
+status: operational
+ste: adapted
+last_updated: 2026-08-31
+---
+
+# Tutorial 0 — Building an Aiko Application on the Constitution
+
+The zeroth tutorial: read this before
+[Using the public Constitution](using_the_public_constitution.md) and
+[Using a private Constitution](using_a_private_constitution.md). It covers one thing: **setting up a new
+Aiko Application so that the Aiko Services Constitution works FOR you**.
+The result: a robust, secure, diagnosable, high-performance application
+that interoperates with Aiko Services and every other Aiko Application.
+You (and your AI coding agent, especially when vibe coding) get this by
+default rather than by luck.
+
+The trick: you never *enforce* the Constitution yourself. You point your
+AI coding agent at it once, and the principles do the steering.
+
+## Step 0 — Choose your starting shape: Pipeline or Actor
+
+There are two reasonable ways to start, and both end at the same place.
+
+| | **(1) Pipeline** — start here if unsure | **(2) Actor** |
+|---|---|---|
+| What it is | A declarative dataflow graph (P8): data "Frames" flow through connected **PipelineElements**, each doing one step | A long-lived distributed service (P2): a mailbox that receives one-way messages and owns its state |
+| Runs as | **One process. No MQTT broker, no Registrar, no Dashboard needed** to begin | Distributed from birth — needs a broker + Registrar |
+| You write | A small JSON definition + (optionally) your own elements — many exist **off-the-shelf** in `src/aiko_services/elements/` (media, control, observe, utilities) | A Python class with methods that become remotely callable |
+| Best first fit | Processing anything step-by-step: media, ML inference, sensor data, text | Services that talk to each other: chat, robots, coordinators |
+| Working example | `src/aiko_services/examples/pipeline/` (`pipeline_example.json` + `elements.py`) | `src/aiko_services/examples/aloha_honua/` (four files, graded) |
+
+**The difference in one breath:** a Pipeline says *what flows through
+what*, as data. An Actor says *who can be told what*, as a service. And
+the secret that makes the choice low-stakes: **a PipelineElement IS an
+Actor/Service under the hood**. A Pipeline that starts life in one quiet
+process becomes discoverable, observable and distributed later, just by
+adding the broker. Your element code does not change. Start simple —
+distribution is a deployment decision, not a rewrite (P8's whole point).
+
+## Step 1 — Create the application repo and install the framework
+
+```bash
+mkdir my_app && cd my_app && git init
+python3 -m venv venv && source venv/bin/activate
+pip install aiko_services
+
+# Alongside (for examples, elements and docs to learn from):
+git clone https://github.com/geekscape/aiko_services.git ~/aiko_services
+```
+
+## Step 2 — Seed `Agents.md` (and the `CLAUDE.md` softlink)
+
+This is the highest-leverage file in your repo: every AI coding session
+loads it automatically. Copy, then adapt the first paragraph:
+
+```markdown
+# MyApp: Agent instructions
+
+MyApp is an Aiko Application built ON the Aiko Services framework
+(github.com/geekscape/aiko_services). It is bound by the framework's
+Constitution — especially the Design Principles P1–P12 in
+`constitution/p_00_DesignPrinciples.md` (adopted by reference,
+content as of <TODAY'S DATE>). When a design choice is unclear, decide
+by appeal to the principles and cite the P-number.
+
+## The principles, one line each (read p_00 for the real text)
+
+- P1  Asynchronous at the protocol level: one-way messages. Methods
+      NEVER return values across the wire. No async/await in
+      framework-facing code.
+- P2  Everything is an Actor. Share nothing. Never block the
+      event-loop thread.
+- P3  Request/response is two messages. Observe state via
+      ECProducer/ECConsumer — getters do not exist.
+- P4  Eventual consistency over consensus.
+- P5  Discovery over configuration: find Services via the Registrar
+      (ServiceFilter). Never hard-code topics or hosts.
+- P6  Everything is a Service — no privileged plane.
+- P7  Design by composition of Interfaces, not inheritance.
+- P8  Topology is declarative data (PipelineDefinitions), not
+      imperative wiring.
+- P9  Edge-first frugality: minimal dependencies. Every buffer
+      bounded. A Raspberry Pi must be able to run it.
+- P10 Elegance is a requirement: the smallest design that composes.
+- P12 Guarded by default: never eval/exec/pickle bus input. Public
+      APIs are deny-all per method.
+
+## Conventions
+
+- Write "Aiko Services" in full — never bare "Aiko". Name ReadMe files
+  `ReadMe.md`, not `README.md`.
+- Identifiers: bare identifiers are local to this repo. Framework
+  identifiers are cited as "framework P3", "framework ADR-002".
+- Learn idioms from the framework's examples, simplest first:
+  `examples/pipeline/` (a Pipeline of PipelineElements — start here) and
+  `examples/aloha_honua/` (a basic Actor). Reuse off-the-shelf elements
+  from `src/aiko_services/elements/` before writing new ones. Concept
+  docs: `documentation/concepts/` (read `design_overview.md` first).
+- Before claiming done: `pytest` green, and no principle violated —
+  in review, cite P-numbers ("rejected: violates P3").
+
+## Commands
+
+    source venv/bin/activate
+    aiko_pipeline create <definition>.json -s 1    # run a Pipeline (single process)
+    mosquitto & aiko_registrar &                   # only when going distributed
+    aiko_dashboard                                 # observe everything (P6)
+```
+
+Then make the softlink (edit `Agents.md`, never the link):
+
+```bash
+ln -s Agents.md CLAUDE.md
+git add Agents.md CLAUDE.md && git commit -m "Seed agent context bound to the Aiko Services Constitution"
+```
+
+## Step 3 — The prompt for your AI coding agent
+
+Short version (starting a session):
+
+```text
+Read Agents.md, the Aiko Services Design Principles at
+https://github.com/geekscape/aiko_services/blob/master/constitution/p_00_DesignPrinciples.md
+and the agent conventions at
+https://github.com/geekscape/aiko_services/blob/master/constitution/g_03_AgentContext.md.
+Build <FEATURE> as an Aiko Services Pipeline of PipelineElements
+(reuse off-the-shelf elements where possible), following the
+examples/pipeline/ pattern. For a long-lived service, use composed
+Actors instead, following examples/aloha_honua/. Comply with P1-P12.
+When unsure, decide by the principles and tell me which P-number
+decided it.
+```
+
+That last clause is the vibe-coding safety net: it makes the agent *show
+its constitutional reasoning*, so drift is visible in one line instead of
+buried in code.
+
+## Step 4 — Verify the plumbing before building anything
+
+**Path (1), Pipeline — one process, no infrastructure:**
+
+```bash
+cd ~/aiko_services
+aiko_pipeline create src/aiko_services/examples/pipeline/pipeline_example.json \
+    -s 1 -p limit 10 -p rate 1
+# Frames flow through the graph and print — the P8 dataflow model,
+# alive on your desk, with nothing else running.
+```
+
+**Path (2), Actor — distributed, three commands of infrastructure:**
+
+```bash
+mosquitto &
+aiko_registrar &
+python -m aiko_services.examples.aloha_honua.aloha_honua &
+aiko_dashboard        # you should SEE your Actor — that is P6 working
+```
+
+Either success is your interoperability floor. And remember the
+convergence: run path (1) today, add path (2)'s broker + Registrar
+whenever you want the same Pipeline discoverable and observable across
+machines — no rewrite.
+
+## Step 5 — As the application grows (three habits, one sentence each)
+
+1. **Cite P-numbers in every review** — cheapest quality gate that exists.
+2. **When a framework rule chafes, do not work around it**: comply, or
+   raise it upstream as a proposal ([Using the public Constitution](using_the_public_constitution.md), Lane B/C) — never a
+   quiet local exception.
+3. **When your app develops its own recurring design rules**, give it a
+   tiny constitution of its own: application principles (AP-1, AP-2 …)
+   in your repo, beneath the framework's. Adopt the framework rules by
+   reference, with a pinned date. The Aiko SDLC application is the worked
+   example of this pattern. Start that file the second time you repeat a
+   design argument, not before.
+
+## Why this works (one paragraph, then go build)
+
+The Design Principles encode the failure modes that AI coding agents
+reliably produce: blocking getters, async creep, unbounded buffers, eval
+on input, hard-coded topics. Each one is a short prohibition with a
+reason. Loading them into every session turns your coding agent from a
+generator of plausible code into a generator of *conformant* code. The
+Pipeline console (then later the Dashboard) makes conformance visible at
+runtime.
+Setup is ten minutes. The payoff is every session afterward.

--- a/documentation/tutorials/using_a_private_constitution.md
+++ b/documentation/tutorials/using_a_private_constitution.md
@@ -1,0 +1,257 @@
+---
+title: Working with a private constitution repository
+description: Developing future code, docs and law in a private downstream repository — routine sync from public, and the promotion ceremony that makes things public
+type: guide
+audience: [project-lead, developers, ai-coding-agents]
+status: operational
+ste: adapted
+last_updated: 2026-08-31
+---
+
+# Working with the private repository — future code, docs and law (a tutorial)
+
+Companion to [Working on Aiko Services — code, law, and the game](using_the_public_constitution.md).
+That tutorial covers the public repo, where you live. This one covers the
+private repo, where the future lives. One idea to hold first:
+
+> **The private repo is a vault with a one-way window. Public changes flow
+> IN routinely (a plain `git merge`). Nothing flows OUT except through the
+> ceremony — content is always COPIED into a fresh public proposal, never
+> merged across.**
+
+## What `aiko_services_future` is — and is not
+
+| It IS | It is NOT |
+|---|---|
+| The private constitution (`future/` — private law, roadmaps, designs) | The everyday code workshop (that is the public repo) |
+| The vault of originals + redaction records + the promotions register | A place whose history may ever reach the public repo |
+| The home of prepared-but-unpublished proposals (`future/pending/`) | A second copy of anything public (the public copy is canonical) |
+
+The map, on branch `andyg/future`:
+
+```
+future/
+  <ClearName>.md        whole private documents (law, designs, roadmaps)
+  adr/                  private ADRs + the full-titles registry
+  potential/            the private roadmap items
+  pending/              prepared public proposals, awaiting their PR
+  originals/            pre-redaction versions of trimmed public docs
+  redactions/*.diff     the exact record of every excision
+  promotions.md         WHAT publishes WHEN, and how to restore it
+  log.md                the private journal
+constitution/           the public law (read-only here; synced from upstream)
+```
+
+## One-time setup
+
+```bash
+git clone git@github.com:geekscape/aiko_services_future.git
+cd aiko_services_future
+git checkout andyg/future
+
+# The public repo as a FETCH-ONLY upstream (pushing to it is disabled):
+git remote add upstream https://github.com/geekscape/aiko_services.git
+git remote set-url --push upstream no-push-upstream-is-fetch-only
+
+# Install the guard and declare the private remote pattern:
+cp <path-to>/guards/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push
+git config constitution.privateremotepattern aiko_services_future
+```
+
+---
+
+## Part 1 — Routine: keep the private repo in sync (public → private)
+
+Do this after any public merge that matters, and before a private work
+session. It is plain plumbing — no ceremony:
+
+```bash
+cd ~/projects/aiko_services_future
+git checkout andyg/future
+git fetch upstream
+git merge upstream/master        # public law + code flow IN
+git push origin andyg/future
+```
+
+Now `constitution/` (public law) and `future/` (private law) sit side by
+side, and private documents can cite public ones by ordinary relative
+paths.
+
+---
+
+## Part 2 — Daily private work: writing future docs and law
+
+**Example: draft a new private design document, `future/s_20_QuantumBus.md`.**
+
+```bash
+cd ~/projects/aiko_services_future
+git checkout andyg/future
+
+$EDITOR future/s_20_QuantumBus.md      # OKF front-matter, as usual
+$EDITOR future/log.md                  # journal it — same commit, same rule
+                                       #   as the public side
+git add future/s_20_QuantumBus.md future/log.md
+git commit -m "future: draft s_20_QuantumBus design"
+git push origin andyg/future           # guard verifies: private remote only
+```
+
+The same registry discipline applies privately: a new private ADR claims
+its number in `future/adr/ReadMe.md` (the full-titles registry) in the
+same commit. Reserved numbers in the PUBLIC registry ("[Reserved for
+private item]") resolve here. If the new document should publish one day,
+**add a row to `future/promotions.md`** with its publish-when condition.
+That row is how future-you finds out it is time.
+
+---
+
+## Part 3 — Private CODE (two options)
+
+Code is normally public from birth (Lane A of the first tutorial). For
+genuinely not-yet-public code, pick one:
+
+**Option 1 — simplest (solo, short-lived):** develop in the *public* repo
+on a local branch and just do not push it until ready. Private-by-omission.
+No backup, single machine — fine for days, not months.
+
+**Option 2 — durable (backed up, multi-machine): a code branch in the
+private repo, based on public master, that NEVER touches `future/`:**
+
+```bash
+cd ~/projects/aiko_services_future
+git fetch upstream
+git checkout -b andyg/secret-widget upstream/master   # clean public ancestry!
+# ...develop: edit src/, tests; commit code files only...
+git push origin andyg/secret-widget                    # backed up privately
+```
+
+The "never touches `future/`" rule is what keeps this branch's history
+publishable later.
+
+**(a) Making the code public**, when the day comes:
+
+```bash
+# 1. In the PUBLIC working repo, fetch the branch one-shot by local path
+#    (no standing remote to the private repo — deliberate):
+cd ~/projects/aiko_services
+git fetch ~/projects/aiko_services_future andyg/secret-widget:andyg/widget
+
+# 2. LEAK-CHECK every commit is tree before any push (non-negotiable):
+git rev-list master..andyg/widget | while read c; do
+  git ls-tree -r --name-only $c | grep -E '^future/' && echo "LEAK in $c"
+done          # expect silence
+
+# 3. Then it is ordinary Lane A: push the branch, open the PR:
+git push origin andyg/widget
+gh pr create --title "Add widget subsystem" --body "..."
+```
+
+If the leak-check ever speaks, stop — rebuild the branch by copying files
+onto a fresh public branch instead.
+
+---
+
+## Part 4 — Promotion (b): future DOCUMENTATION becomes public
+
+**Example: `future/pending/g_01_v08_update.md` (a prepared update to the
+public release guide).** Promotion is a **move in the game** — the content
+is COPIED out. The repos never merge upward:
+
+```bash
+# In the PUBLIC repo — the proposal:
+cd ~/projects/aiko_services
+git checkout -b andyg/proposal-g01-v08
+git -C ~/projects/aiko_services_future show \
+    andyg/future:future/pending/g_01_v08_update.md \
+    > constitution/g_01_ReleaseProcessGuide.md
+$EDITOR constitution/log.md            # public journal entry
+git add constitution/g_01_ReleaseProcessGuide.md constitution/log.md
+git commit -m "Proposal: g_01 v0.8 release-process update"
+git push origin andyg/proposal-g01-v08
+gh pr create --title "Proposal: g_01 v0.8 release-process update" --body "..."
+# → gates run → lead ratifies → merge = enactment
+```
+
+**Afterward, close the loop in the private repo:**
+
+```bash
+cd ~/projects/aiko_services_future
+git checkout andyg/future
+git fetch upstream && git merge upstream/master   # the promotion arrives
+git rm future/pending/g_01_v08_update.md future/pending/g_01_v08_update.diff
+$EDITOR future/promotions.md                      # erase the row
+$EDITOR future/log.md                             # journal the promotion
+git commit -am "future: g_01 v0.8 update promoted — pending entry retired"
+git push origin andyg/future
+```
+
+## Part 5 — Promotion (c): future CONSTITUTION becomes public
+
+The same skeleton, plus **restoration** — reserved numbers get their real
+titles back, and redacted text returns to the published documents.
+**Example: publishing a private ADR when its subject matter ships:**
+
+```bash
+cd ~/projects/aiko_services
+git checkout -b andyg/proposal-publish-adr-NNN
+
+# 1. The document itself:
+git -C ~/projects/aiko_services_future show \
+    andyg/future:future/adr/ADR-NNN_ItsRealName.md \
+    > constitution/adr/ADR-NNN_ItsRealName.md
+
+# 2. RESTORE the registry row: replace "[Reserved for private item]"
+#    with the real title — same number, never a new one:
+$EDITOR constitution/adr/ReadMe.md
+
+# 3. RESTORE redacted references: find every bracket marker the
+#    redaction left behind, and reverse the matching hunk from the
+#    private repo's future/redactions/*.diff record:
+grep -rn "Privately maintained\|Reserved for private item" constitution/ \
+    | grep -i <topic>                  # locate the sites
+$EDITOR constitution/<each-affected-file>.md
+
+# 4. TRIM the stems so CI *proves* the restoration is complete:
+$EDITOR documentation/tools/constitution_stems.txt   # remove this item's stems
+
+# 5. Index row + journal, commit everything TOGETHER, propose:
+$EDITOR constitution/ReadMe.md constitution/log.md
+git add constitution/adr/ADR-NNN_ItsRealName.md constitution/adr/ReadMe.md \
+        documentation/tools/constitution_stems.txt constitution/ReadMe.md \
+        constitution/log.md <each-affected-file>
+git commit -m "Proposal: publish ADR-NNN (promotion — subject matter shipped)"
+git push origin andyg/proposal-publish-adr-NNN
+gh pr create --title "Proposal: publish ADR-NNN" --body "Promotion per
+future/promotions.md; condition met: <the condition>."
+# → gates enforce completeness (a leftover reference to a trimmed stem
+#   now FAILS CI) → lead ratifies → merge
+```
+
+Private-side closure, as in Part 4: sync down, `git rm` the promoted file
+from `future/`, retire its redaction record, erase its register row,
+journal, push.
+
+---
+
+## Cheat sheet
+
+| You want to… | Where | How |
+|---|---|---|
+| Pull public changes into the vault | private | `fetch upstream && merge upstream/master && push origin` — routine |
+| Write/edit private law or future docs | private, `andyg/future` | Edit + `future/log.md` entry, same commit; push origin |
+| Develop not-yet-public code | private, code branch off `upstream/master` | Never touch `future/` on that branch |
+| Publish that code (a) | public | One-shot fetch by path → **leak-check** → ordinary PR |
+| Publish a future doc (b) | public | COPY content → proposal PR → gates → ratify → private cleanup |
+| Publish future law (c) | public | Copy + restore registry rows + reverse redactions + trim stems → proposal PR → private cleanup |
+
+## The pitfalls (each one guarded, but know them)
+
+- **Never `git merge` or cherry-pick from private into public.** Content
+  crosses by copy, into fresh public commits, only. (The push URL to
+  upstream is disabled and the guard blocks `andyg/future` everywhere but
+  the private origin — but the rule is yours to keep, not just the guard's.)
+- **Anything fetched from the private repo into a public working clone
+  must be leak-checked before any push from that clone.**
+- **`future/` paths can never appear in a public commit** — the public
+  repo's pre-commit denylist refuses them. If it fires, it is working.
+- **Every promotion updates `future/promotions.md`** — the register
+  shrinking is the measure of the private constitution publishing itself.

--- a/documentation/tutorials/using_the_public_constitution.md
+++ b/documentation/tutorials/using_the_public_constitution.md
@@ -1,0 +1,229 @@
+---
+title: Working on Aiko Services — code, law, and the game
+description: The three lanes of contribution — everyday coding (no ceremony), bumping into a rule, and making a move in the game — with full command and GitHub steps
+type: guide
+audience: [developers, ai-coding-agents]
+status: operational
+ste: adapted
+last_updated: 2026-08-31
+---
+
+# Working on Aiko Services — code, law, and the game (a tutorial)
+
+Preceded by [Tutorial: First project](first_project.md). Followed by
+[Using a private Constitution](using_a_private_constitution.md).
+
+For newcomers to Aiko Services, its SDLC, and its Nomic-style constitution.
+One idea to hold before everything else:
+
+> **Almost all work is ordinary coding. The constitution is the rulebook
+> you follow, not a form you fill in. You only touch the rulebook itself
+> on the rare day you want to change a rule. That change is a special,
+> pleasant ceremony called "a move in the game".**
+
+There are three lanes. Lane A is where you live. Lane B is a fork you hit
+occasionally. Lane C is rare and deliberate.
+
+---
+
+## Lane A — Everyday coding (~90% of all work)
+
+**Example task: fix a bug in `lease.py` and add a unit test.**
+
+### One-time setup
+
+```bash
+git clone https://github.com/geekscape/aiko_services.git
+cd aiko_services
+pip install -e .
+pytest                      # confirm the suite runs before you change anything
+```
+
+### The daily loop
+
+```bash
+# 1. Never work on master. Make a branch (one branch = one task):
+git checkout -b yourname/fix-lease-timer
+
+# 2. Edit code and tests. Run the tests:
+pytest
+flake8 . --select=E9,F63,F7,F82
+
+# 3. Commit — stage files BY NAME, never a whole directory:
+git add src/aiko_services/main/lease.py src/aiko_services/tests/unit/test_lease.py
+git commit -m "Fix Lease extension-timer cadence; add regression test"
+
+# 4. Push your branch and open a pull request:
+git push origin yourname/fix-lease-timer
+gh pr create --title "Fix Lease extension-timer cadence" \
+             --body "Pins the bug with a regression test."
+
+# 5. CI runs (flake8 + pytest). When green and approved, it merges.
+#    Then update your local master:
+git checkout master && git pull
+```
+
+### Where is the constitution in all this?
+
+Invisible, and that is the point. It shaped your work without appearing:
+
+- You followed the design principles (`constitution/p_00_DesignPrinciples.md`)
+  — no `async def`, no methods returning values across the wire, no direct
+  `self.share[...]` writes. A reviewer might say "rejected: violates P3" —
+  that is the rulebook being *cited*, not changed.
+- The pre-commit guard checked your staged files against the denylist and
+  passed silently, because you did not stage anything private.
+- The `constitution` CI check did not even run — your PR touched only code.
+
+**You needed zero constitutional steps.** Most PRs, forever, look like this.
+
+---
+
+## Lane B — Coding that bumps into a rule (occasional)
+
+Sometimes mid-task you hit a rule. There are exactly three shapes:
+
+### B1. Your change would break a principle
+
+Say you want `get_status()` to return a value over the wire. P3 forbids
+RPC-style getters. Rule G1 gives you no third option:
+
+- **Either** redesign (publish status as EC shared state — the compliant
+  pattern), **and carry on in Lane A**.
+- **or** you believe the *principle* is wrong — then you stop coding and
+  make a **Lane C move** (propose amending P3 with an ADR). This is rare.
+
+### B2. Your work implements a decision that deserves a durable record
+
+You built something with a rationale worth keeping (a wire-format choice,
+a boundary rule). That is an **ADR** — a small Lane C move, made *in the
+same PR* as your code:
+
+1. Open `constitution/adr/ReadMe.md`. Find the next **free** number.
+2. Add the registry row **and** create `constitution/adr/ADR-NNN_YourName.md`
+   (Context / Decision / Consequences / Evidence) **in the same commit**.
+   The registry owns the numbers — never cite a number you have not
+   claimed.
+3. Add a dated entry to `constitution/log.md`.
+
+### B3. You shipped a feature — update its docs
+
+`documentation/concepts|elements|examples` docs for shipped behavior are
+**Lane A** — ordinary committable work, same PR as the code, no ceremony.
+
+---
+
+## Lane C — A move in the game (rare, deliberate)
+
+A **move** is a PR that changes the rulebook itself: anything under
+`constitution/`, the `.constitution-guard` denylist, `Agents.md`, or the
+CI gates. Every move has the same skeleton:
+
+> **propose → check → ratify → enact → journal**
+
+**Worked example — the smallest real queued move** (docket item 23:
+add `ZZ*` case-variants to the denylist):
+
+```bash
+# 1. PROPOSE — a branch and the change:
+git checkout -b yourname/proposal-guard-zz-variants
+$EDITOR .constitution-guard          # add the [Zz][Zz]* patterns
+
+# 2. JOURNAL — every substantive rulebook change logs itself, same commit:
+$EDITOR constitution/log.md          # add under a "## 2026-MM-DD" heading:
+#   - **Update** — .constitution-guard: added [Zz][Zz]* case-variant
+#     patterns so the denylist matches the working-tree ignore rule.
+
+# 3. Run the gates locally (optional but polite — CI runs them anyway):
+python3 documentation/tools/check_self_containment.py \
+    --future-stems documentation/tools/constitution_stems.txt \
+    constitution/ Agents.md documentation/ReadMe.md
+
+# 4. Commit (explicit file list!) and open the PR, titled as a proposal:
+git add .constitution-guard constitution/log.md
+git commit -m "Proposal: denylist case-variant patterns [Zz][Zz]*"
+git push origin yourname/proposal-guard-zz-variants
+gh pr create --title "Proposal: denylist case-variant patterns" \
+             --body "Adds [Zz][Zz]* to .constitution-guard. Evidence: five
+ZZZZZ*-prefixed personal notes found uncovered on 2026-08-31."
+```
+
+**Then GitHub takes over — the constitutional steps:**
+
+5. **CHECK** — the `gates` CI job runs automatically: the self-containment
+   scan (no references to private material) and the STE lint. Red gates
+   block the merge. No human can skip them.
+6. **RATIFY** — the project lead reviews. The lead's approval is the
+   ratification (Code Owners rule). A PR author can never approve their
+   own PR. So the lead merging their own proposal uses the visible admin
+   allowance — on the record, in the PR timeline.
+7. **ENACT** — the merge *is* the enactment. GitHub's PR number is the
+   proposal's number in the ledger, adopted or not, forever.
+
+That is a complete Nomic move: the rules changed *by* the rules. Five
+minutes of work, permanently on the record.
+
+**Second example — promoting private material** (docket item 22, the
+prepared g_01 update): identical skeleton, plus the content comes *from*
+the private repo:
+
+```bash
+git checkout -b yourname/proposal-g01-v08-update
+# copy the prepared full text from the private repo:
+git -C ~/projects/aiko_services_future show andyg/future:future/pending/g_01_v08_update.md \
+    > constitution/g_01_ReleaseProcessGuide.md
+$EDITOR constitution/log.md          # journal entry
+git add constitution/g_01_ReleaseProcessGuide.md constitution/log.md
+git commit -m "Proposal: g_01 v0.8 release-process update"
+# ... push, PR, gates, ratify, merge — as above.
+# Afterward, in the private repo: delete future/pending/g_01_v08_update.*
+# and sync (see below). Never `git merge` between the two repos.
+```
+
+---
+
+## The two repositories, in one breath
+
+- **`aiko_services`** (public): all code, all public docs, the public
+  rulebook. You work here.
+- **`aiko_services_future`** (private): the private rulebook (`future/`).
+  Only the project lead works here, only on branch `andyg/future`.
+  - Sync **down** (routine): `git fetch upstream && git merge upstream/master`
+    on `andyg/future`, then `git push origin andyg/future`.
+  - Promote **up** (always a Lane C move): copy content into a fresh
+    public proposal PR. Never merge or cherry-pick across the repos.
+
+## "A session's turn" (for multi-AI-session work)
+
+When several Claude Code sessions work in parallel, **code work runs in
+parallel** (separate branches/worktrees — ordinary Lane A). But the
+*rulebook* is a shared resource, so **rulebook changes take turns**: one
+session at a time holds custody, ports its constitutional updates together
+with its code merge, and hands off. If you are a solo human contributor,
+you can ignore this section entirely.
+
+## Cheat sheet — "am I making a move?"
+
+| You are… | Lane | Constitutional steps |
+|---|---|---|
+| Fixing code, adding tests/features | A | None. Branch → PR → merge |
+| Writing docs for shipped behavior | A | None |
+| Blocked by a principle | B1 | Comply and continue — or escalate to a Lane C amendment proposal |
+| Recording a durable design decision | B2 | Claim ADR number + file + journal entry, in your code PR |
+| Changing anything in `constitution/`, the denylist, `Agents.md`, or the gates | **C** | Proposal PR + registry rows + journal entry → gates → lead ratifies → merge |
+
+## Mini-glossary
+
+- **Move / proposal** — a PR that changes the rulebook, played by the rules.
+- **Gates** — the automatic CI checks every proposal must pass (stage-1 of
+  the ceremony): self-containment + STE lint.
+- **Ratify** — the project lead's review approval. Nothing becomes law
+  without it.
+- **Journal** — `constitution/log.md`. Every rulebook change writes one
+  dated line about itself, in the same commit.
+- **Registry** — the table that owns identifier numbers (ADRs,
+  principles). Claim the number in the same change that uses it. Numbers
+  are never reused.
+- **Guard** — the local git hooks that refuse private material and
+  unreviewed pushes. If a guard refuses you, it is working: stop and ask,
+  never `--no-verify`.

--- a/src/aiko_services/__init__.py
+++ b/src/aiko_services/__init__.py
@@ -1,7 +1,7 @@
 import aiko_services.main
 
 __version__ = "0.8-dev"
-__id__ = "2026-08-15_a"
+__id__ = "2026-08-31_a"
 
 from aiko_services.main import *
 aiko.id = __id__        # aiko = main.process.ProcessData


### PR DESCRIPTION
New quick start guide and the three-level tutorials ladder (Start / Create / Advanced), ReadMe Documentation section reordered with Constitution link, diagrams index with rendered-view links, journal entry. All new documents STE adapted, earned at lint zero. Carries __id__ 2026-08-31_a.