### PR TITLE
Proposal: personal-note denylist case-variant patterns

### DIFF
--- a/.constitution-guard
+++ b/.constitution-guard
@@ -11,6 +11,13 @@ documentation/z_*
 _aiko_setup.sh
 _aiko_setup.txt
 
+# Personal notes, case variants, any depth (mirrors the .gitignore rule
+# committed in the same change as this amendment)
+[zZ]_*
+*/[zZ]_*
+[zZ][zZ]*_*
+*/[zZ][zZ]*_*
+
 # Backups and tool residue
 *_backup/*
 documentation/constitution_backup/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Personal working notes, any depth (z_/Z_ prefix; multi-z prefixes
+# carry an underscore somewhere, e.g. ZZ_*, zz_notes, ZZZZZ_*)
+[zZ]_*
+[zZ][zZ]*_*
+
 data_out/
 
 # Tools

--- a/constitution/log.md
+++ b/constitution/log.md
@@ -6,6 +6,15 @@ Every substantive change appends an entry under its date heading
 This journal begins at the constitution's first public release. The
 pre-publication history is maintained privately.
 
+## 2026-09-01
+
+- **Update** — .constitution-guard: added the personal-note case-variant
+  patterns [zZ]_* and [zZ][zZ]*_*, at top level and at depth, and the
+  matching ignore rules are committed in the same change [.gitignore].
+  The multi-z form deliberately needs an underscore, so ordinary files
+  that merely start with "zz" are never swept up. Evidence: ZZ-prefixed
+  personal notes found uncovered by the 2026-08-31 cleanup.
+
 ## 2026-08-31
 
 - **Creation** — [diagrams/ReadMe.md](diagrams/ReadMe.md): index for the


### PR DESCRIPTION
Adds [zZ]_* and [zZ][zZ]*_* to .constitution-guard, at top level and at depth, and commits the matching .gitignore rules in the same change. The multi-z form deliberately carries an underscore, so ordinary files that merely start with zz are never swept up. Evidence: ZZ-prefixed personal notes found uncovered by the 2026-08-31 cleanup. Docket item 23.

🙋‍♂️🤖 assisted by [Claude Fable 5]