### PR TITLE
Proposal: ADR-003 - HyperSpace/Storage UID address-space allocation

### DIFF
--- a/constitution/adr/ADR-003_UidAddressSpaces.md
+++ b/constitution/adr/ADR-003_UidAddressSpaces.md
@@ -1,0 +1,113 @@
+---
+title: "ADR-003 — HyperSpace/Storage UID address-space allocation"
+description: Reserves 48-bit UID address spaces MAC-style — leading nibble 0
+  for Aiko Services development (sub-classed by governance tier), leading
+  nibble f for future development, all other leading nibbles for third
+  parties — and defines the class-octet / identity-octets split
+type: adr
+audience: [project-lead, architects, developers, ai-coding-agents]
+status: normative
+ste: adapted
+related: [ReadMe, ../p_00_DesignPrinciples]
+last_updated: 2026-09-01
+---
+
+# ADR-003 — HyperSpace/Storage UID address-space allocation
+
+## Context
+
+HyperSpace/Storage entry UIDs gain a third generation mode: (1) random,
+(2) predictable one-up integers for debugging, (3) caller-specified. A
+caller-specified storage identity can equal a registry identity, for
+example a Nomic(Law) rule number. Caller-specified UIDs need an allocation policy:
+who may mint what, and how third-party entries stay collision-free from
+constitutional ones. The proven model is the IEEE MAC address registry —
+an authority prefix plus a device identity.
+
+## Decision
+
+**Core scheme.** UIDs are 48 bits, written as six colon-separated octets
+(`hh:hh:hh:hh:hh:hh`). Three allocation modes exist — random, automatic
+one-up, and specified. The leading nibble allocates the address space,
+and each space carries its own **default mode**:
+
+| Leading nibble | Space | Use | Default mode |
+|---|---|---|---|
+| `0` | **Aiko Services development** | Constitutional and framework entries, sub-classed by governance tier (immutable / core / epochal) | **specified** |
+| `1`–`e` | **Third parties** | Free for external use — self-minted; a prefix registry may follow when element packaging lands | **random** |
+| `f` | **Aiko Services future** | Reserved for future development and other purposes | **specified** |
+
+The defaults are themselves a guard: nothing lands in a reserved space by
+accident, because reserved spaces are never randomly minted by default —
+entering them takes a deliberate, specified act. Automatic one-up remains
+available in every space as an explicit debugging configuration.
+
+**Extension scheme (longer UIDs).** An Aiko Application may adopt any UID
+definition its needs dictate: a longer hexadecimal number, RFC 9562 UUIDs
+(UUIDv7 timestamp+random, UUIDv4 random, or any of the eight defined
+versions), or any byte encoding of any length. Two rules bind every
+extension:
+
+1. **The core scheme is a subset of any extended scheme.** The 48-bit
+   allocation above stays valid and meaningful inside the longer format.
+2. **Embedding is left-justified, space-padded.** A core UID extends by
+   prepending it — core octets at the most-significant end — with the
+   padding fill **matching the space marker**: a `0`-space core UID pads
+   the remainder with `0` nibbles, and an `f`-space core UID pads with
+   `f` nibbles. The leading-nibble classification therefore survives
+   extension unchanged. The two reserved spaces occupy the extremes of
+   any extended number space. Aiko Services development sits at the very
+   bottom, Aiko Services future at the very top, and third parties in
+   the broad middle.
+
+*Discriminator note.* Third-party UUIDs of standard versions can begin
+with a reserved nibble by their own rules (a contemporary UUIDv7's
+leading timestamp bits begin with `0` for the current era, and one
+eighth of UUIDv4s begin with `0` or `f` by chance). The test for an
+extended Aiko-space UID therefore has two halves. The leading nibble
+must be **reserved**, AND the padding tail beyond the core 48 bits must
+be **uniformly that space's fill** (all-`0` for the `0` space, all-`f`
+for the `f` space). A standard UUIDv4/v7 meets both halves with
+probability ≈ 2^-80, negligible by construction. Range classification
+in extended schemes always tests both halves of this condition. A store declares its UID scheme in its
+configuration (CP-G: a scheme change is a versioned change), and
+validation is per scheme.
+
+**Class–identity split (the OUI lesson).** Within a reserved space, the
+**high octet carries the class** (space nibble + tier sub-class) and the
+**low octets carry the stable identity number**. The identity octets are
+frozen — never renumbered, never reused (the registry discipline). A
+transmutation (a tier change) rewrites only the class octet. The identity
+number persists, and the registry records both forms of the succession.
+Identity therefore never depends on class, and class is always mechanically
+readable from the address.
+
+**Enforcement.** Caller-specified UIDs are validated against this
+allocation: duplicate UIDs are rejected, and a proposer may mint only
+within the ranges its declared authority allows. The gate checks
+allocation by range comparison at stage 2. The machine constitution
+declares per-proposer `uid_ranges`.
+
+## Consequences
+
+- Constitutional entries and third-party entries cannot collide by
+  construction. 14/16 of the space belongs to third parties, and each
+  reserved space still holds 2^44 identities.
+- Governance class is visible in the address itself. Tooling, the gate
+  and the committed storage tree can classify an entry without a lookup.
+  A CI lint can verify that constitutional entries sit in their range.
+- Anti-wireheading gains an addressing form: an entry claiming a
+  `0`-space UID is refused unless the gate minted it.
+- Transmutation does not break the frozen-identifier rule, because
+  identity lives in the low octets only.
+- Third-party self-minting is collision-safe today (random within 44+
+  bits). A vendor prefix registry, when the shareable-element ecosystem
+  needs one, extends this table rather than replacing it.
+
+## Evidence trail
+
+Storage UID mode 3 (E1 plan revision 11) and the address-space reservation
+directed by the project lead (2026-08-27). Precedents: IEEE OUI/EUI-48
+allocation, RFC 1918 reserved ranges, RFC 4122 variant/version bits. P10
+(stand on established theory), P8 (identity as declarative data), registry
+discipline (t_03 — registries own numbers, and identifiers are frozen).

--- a/constitution/adr/ReadMe.md
+++ b/constitution/adr/ReadMe.md
@@ -8,7 +8,7 @@ audience: [project-lead, architects, developers, ai-coding-agents]
 status: operational
 ste: adapted
 related: [../p_01_PrinciplesGovernance, ../p_00_DesignPrinciples]
-last_updated: 2026-08-27
+last_updated: 2026-09-01
 ---
 
 # Aiko Services Architectural Decision Records
@@ -38,7 +38,7 @@ deferral promotion, retirement). Use one for any decision worth a durable ration
 |-----|-----------------|--------|------------|
 | 001 | *(released 2026-07-13 — was only a placeholder series-anchor citation, never written; number retired unused)* | released | — |
 | [002](ADR-002_SExpressionWireEncoding.md) | S-expressions over JSON/protobuf (wire encoding rationale) | normative (founding decision; backfill record written 2026-07-13) | s_00_Specifications §1.1 |
-| 003 | — | free | |
+| [003](ADR-003_UidAddressSpaces.md) | HyperSpace/Storage UID address-space allocation — 48-bit MAC-style spaces [leading nibble 0 = Aiko Services development, f = Aiko Services future, 1–e third parties], class-octet / identity-octets split, space-fill extension embedding | normative (accepted 2026-09-01) | Storage UID mode 3 rollout — shared specification with the CRC-cards session |
 | 004 | — | free | |
 | 005 | — | free | |
 | 006 | Agent in the interface chain; thin-interface constraint; cognition boundary rule | claimed | e_03_FirstClassAgents T1 |

--- a/constitution/log.md
+++ b/constitution/log.md
@@ -8,6 +8,11 @@ pre-publication history is maintained privately.
 
 ## 2026-09-01
 
+- **Creation** — [adr/ADR-003_UidAddressSpaces.md](adr/ADR-003_UidAddressSpaces.md):
+  HyperSpace/Storage UID address-space allocation — 48-bit MAC-style
+  spaces, class-octet / identity-octets split, space-fill extension
+  embedding rule. Number claimed from the registry in the same change;
+  shared specification with the CRC-cards session.
 - **Update** — .constitution-guard: added the personal-note case-variant
   patterns [zZ]_* and [zZ][zZ]*_*, at top level and at depth, and the
   matching ignore rules are committed in the same change [.gitignore].


### PR DESCRIPTION
48-bit MAC-style UID spaces: leading nibble 0 = Aiko Services development [sub-classed by governance tier], f = future, 1-e third parties. Class-octet / identity-octets split; space-fill extension embedding. Number claimed from the registry in the same change. Docket item 1 — shared specification with the CRC-cards session.

🙋‍♂️🤖 assisted by [Claude Fable 5]