### PR TITLE
v0.8 pre-release: harden the test infrastructure

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,4 +1,5 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# This workflow will install Python dependencies, run tests and lint across
+# the supported Python versions (see "requires-python" in pyproject.toml)
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python application
@@ -6,6 +7,7 @@ name: Python application
 on:
   push:
     branches: [ "master" ]
+    tags: [ "v*" ]
   pull_request:
     branches: [ "master" ]
 
@@ -16,13 +18,17 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.13
-      uses: actions/setup-python@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.13"
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -95,7 +95,7 @@ python3 -m venv venv      # Once only
 source venv/bin/activate  # Each terminal session
 pip install -U pip        # Install latest pip
 pip install -U hatch      # Install latest Hatch build and package manager
-# hatch test              # Run local tests (to be completed)
+hatch run test            # Run the unit test suite (no MQTT server required)
 hatch build               # Build Aiko Services package: dist/*.whl and dist/*.tar.gz
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "aiko_services"
 version = "0.7"
 readme = "ReadMe.md"
 description = "Distributed embedded service framework for A.I and robotics"
-requires-python = ">=3.9.0,<=3.14.6"
+requires-python = ">=3.9.0,<3.15"
 
 authors = [
     {name = "Andy Gelme", email = "geekscape@gmail.com"}
@@ -105,8 +105,8 @@ exclude = [
     "venv*"
 ]
 
-[tool.hatch.envs.default]
-pytest = "^8.0"
-
 [tool.hatch.envs.default.scripts]
-test = "pytest {args:tests}"
+test = "pytest {args:src/aiko_services/tests/unit}"
+
+[tool.pytest.ini_options]
+testpaths = ["src/aiko_services/tests/unit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: MacOS",
@@ -40,14 +41,22 @@ dependencies = [
     "click~=8.1.7",
     "numpy>=1.26.4",
     "paho-mqtt>=1.6.1,<2.0.0",
-    "Pillow~=10.4.0",
-    "psutil~=6.0.0",
+    # Pinned binary deps: the versions below 3.14 are the long-tested
+    # pins, which publish no cp314 wheels. Python 3.14 uses the first
+    # wheel-bearing releases instead (environment markers keep the
+    # tested pins untouched for 3.9-3.13)
+    "Pillow~=10.4.0; python_version < '3.14'",
+    "Pillow>=11.3; python_version >= '3.14'",
+    "psutil~=6.0.0; python_version < '3.14'",
+    "psutil>=7.0; python_version >= '3.14'",
     "pyperclip~=1.9.0",
     "pytest~=8.3.4",
-    "pyzmq~=26.2.0",
+    "pyzmq~=26.2.0; python_version < '3.14'",
+    "pyzmq>=27.0; python_version >= '3.14'",
     "requests~=2.32.3",
     "transitions~=0.9.2",
-    "wrapt~=1.16.0"
+    "wrapt~=1.16.0; python_version < '3.14'",
+    "wrapt>=1.17.3; python_version >= '3.14'"
 ]
 
 # [project.optional-dependencies]

--- a/src/aiko_services/examples/colab/elements.py
+++ b/src/aiko_services/examples/colab/elements.py
@@ -50,7 +50,7 @@ class ConvertDetections(aiko.PipelineElement):
         message = ""
         for object in overlay["objects"]:
             delimiter = "," if message else ""
-            message += f"{delimiter}{object["name"]}"  # object["confidence"]
+            message += f"{delimiter}{object['name']}"  # object["confidence"]
         return aiko.StreamEvent.OKAY, {"message": message}
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Test baseline hardened: hatch run test / pytest pinned to the unit suite; CI matrix Python 3.9-3.14 with fail-fast off, plus v* tag-push runs; requires-python >=3.9.0,<3.15 [an exact-patch ceiling refused 3.14.7]. Version stays 0.7 — this is pre-release hardening, not the release. Prepared by the v0.8 release session 2026-08-28; merging closes open question 15 and unblocks the g_01 guide promotion.