### PR TITLE
Documentation: fix stale pre-split constitution paths

### DIFF
--- a/documentation/concepts/ReadMe.md
+++ b/documentation/concepts/ReadMe.md
@@ -29,7 +29,7 @@ Format (OKF) conventions:
 
 The full section structure and writing guidance is defined in the
 constitution's OKF Concepts documentation template
-(`documentation/constitution/t_00_OkfConceptTemplate.md`).
+(`constitution/t_00_OkfConceptTemplate.md`).
 
 ## Start here
 

--- a/documentation/elements/ReadMe.md
+++ b/documentation/elements/ReadMe.md
@@ -28,7 +28,7 @@ and in particular on these five documents:
 [Data Source / Target](../concepts/data_source_target.md) and
 [Scheme](../concepts/scheme.md). They follow the same
 audience-first template
-(`documentation/constitution/t_00_OkfConceptTemplate.md`).
+(`constitution/t_00_OkfConceptTemplate.md`).
 
 ## Packages
 

--- a/documentation/elements/control/ReadMe.md
+++ b/documentation/elements/control/ReadMe.md
@@ -16,7 +16,7 @@ OKF documentation for `src/aiko_services/elements/control/` — the
 PipelineElements that alter Pipeline graph control flow. One document per
 source module, following the structure defined in the constitution's OKF
 Concepts documentation template
-(`documentation/constitution/t_00_OkfConceptTemplate.md`).
+(`constitution/t_00_OkfConceptTemplate.md`).
 
 ## Module documents
 

--- a/documentation/elements/observe/ReadMe.md
+++ b/documentation/elements/observe/ReadMe.md
@@ -16,7 +16,7 @@ OKF documentation for `src/aiko_services/elements/observe/` — the
 PipelineElements that give observability from inside a Pipeline
 graph. One document per source module, following the structure defined
 in the constitution's OKF Concepts documentation template
-(`documentation/constitution/t_00_OkfConceptTemplate.md`).
+(`constitution/t_00_OkfConceptTemplate.md`).
 
 ## Module documents
 

--- a/documentation/elements/utilities/ReadMe.md
+++ b/documentation/elements/utilities/ReadMe.md
@@ -17,7 +17,7 @@ OKF documentation for `src/aiko_services/elements/utilities/` — the
 general-purpose PipelineElements and shared helpers used across the
 element packages. One document per source module, following the
 structure defined in the constitution's OKF Concepts documentation
-template (`documentation/constitution/t_00_OkfConceptTemplate.md`).
+template (`constitution/t_00_OkfConceptTemplate.md`).
 
 ## Module documents
 

--- a/documentation/examples/ReadMe.md
+++ b/documentation/examples/ReadMe.md
@@ -30,7 +30,7 @@ committed HyperSpace data tree with its own source `ReadMe.md`.
 
 These documents follow the same audience-first template as the
 Concepts and PipelineElements documentation
-(`documentation/constitution/t_00_OkfConceptTemplate.md`).
+(`constitution/t_00_OkfConceptTemplate.md`).
 
 ## Packages
 

--- a/documentation/tools/ReadMe.md
+++ b/documentation/tools/ReadMe.md
@@ -36,7 +36,7 @@ part of the governance tooling that is public.
 ## asd_ste100_lint.py — the verification gate
 
 ```bash
-python3 documentation/tools/asd_ste100_lint.py documentation/constitution/*.md
+python3 documentation/tools/asd_ste100_lint.py constitution/*.md
 ```
 
 Each line of the report gives one file and seven counts:
@@ -138,8 +138,8 @@ in review, do not "fix" them:
 ## asd_ste100_fix.py — the mechanical pass
 
 ```bash
-python3 documentation/tools/asd_ste100_fix.py documentation/constitution/*.md    # dry run
-python3 documentation/tools/asd_ste100_fix.py --write documentation/constitution/*.md
+python3 documentation/tools/asd_ste100_fix.py constitution/*.md    # dry run
+python3 documentation/tools/asd_ste100_fix.py --write constitution/*.md
 git diff documentation/                                                     # review
 ```
 


### PR DESCRIPTION
Nine live references still pointed at documentation/constitution/, which moved to the top-level constitution/ tree at the 2026-08-27 public split: six OKF template pointers in the concepts, elements and examples guides, and three lint command examples in the tools guide. Historical mentions that describe the past accurately are untouched.

🙋‍♂️🤖 assisted by [Claude Fable 5]