### PR TITLE
fix(process): allocate service_id from a monotonic counter, not the live count

### DIFF
--- a/src/aiko_services/main/process.py
+++ b/src/aiko_services/main/process.py
@@ -144,7 +144,8 @@ class ProcessImplementation(ProcessData):
     def __init__(self):
         self.initialized = False
         self.running = False  # TODO: Replace with StateMachine (see actor.py)
-        self.service_count = 0
+        self.service_count = 0    # live count: goes up and down
+        self._service_id_last = 0  # monotonic: only ever goes up
 
         self._exit_status = 0
         self._message_handlers = {}
@@ -257,7 +258,13 @@ class ProcessImplementation(ProcessData):
         try:
             self._services_lock.acquire("add_service()")
             self.service_count += 1
-            service.service_id = self.service_count
+            # Allocate from the monotonic counter, never from "service_count".
+            # "service_count" is decremented by remove_service(), so using it as
+            # the allocator reissues the id of a Service that is still live once
+            # a non-last Service has been removed: the new Service overwrites the
+            # previous holder in "_services" and the two share a topic_path
+            self._service_id_last += 1
+            service.service_id = self._service_id_last
             service.topic_path = aiko.get_topic_path(service.service_id)
             self._services[service.service_id] = service
         finally:

--- a/src/aiko_services/main/process.py
+++ b/src/aiko_services/main/process.py
@@ -258,11 +258,8 @@ class ProcessImplementation(ProcessData):
         try:
             self._services_lock.acquire("add_service()")
             self.service_count += 1
-            # Allocate from the monotonic counter, never from "service_count".
-            # "service_count" is decremented by remove_service(), so using it as
-            # the allocator reissues the id of a Service that is still live once
-            # a non-last Service has been removed: the new Service overwrites the
-            # previous holder in "_services" and the two share a topic_path
+            # Never allocate from "service_count": remove_service() decrements it,
+            # so it reissues an id that a live Service still holds
             self._service_id_last += 1
             service.service_id = self._service_id_last
             service.topic_path = aiko.get_topic_path(service.service_id)

--- a/src/aiko_services/tests/unit/test_process.py
+++ b/src/aiko_services/tests/unit/test_process.py
@@ -1,0 +1,99 @@
+# Usage
+# ~~~~~
+# pytest [-s] unit/test_process.py
+# pytest [-s] unit/test_process.py::test_service_id_not_reused_after_remove
+#
+# Regression tests for Service identity allocation in "process.py".
+#
+# add_service() assigns "service_id", from which "topic_path" is built, and
+# "topic_path" is the Service's identity on the bus. So the allocator must
+# never issue an id that a live Service already holds.
+#
+# The bug these cover: "service_count" was both the live count (decremented by
+# remove_service()) and the id allocator. Remove a non-last Service, add
+# another, and the new Service takes the removed id, which is still held by a
+# live Service: the new one overwrites the previous holder in "_services", and
+# both carry the same topic_path.
+#
+# Reachable through hyperspace.py:296, which calls remove_service() when an
+# empty Category is destroyed.
+#
+# To Do
+# ~~~~~
+# - None, yet !
+
+import aiko_services as aiko
+
+
+class ServiceStub:
+    # A payload, not a Service: these tests exercise the allocator in
+    # add_service() / remove_service(), which never inspects the object beyond
+    # "protocol". "protocol" is None so the Registrar publish is skipped, and
+    # no broker is needed
+    def __init__(self, label):
+        self.label = label
+        self.service_id = None
+        self.topic_path = None
+        self.protocol = None
+
+
+def _fresh_process():
+    # "aiko.process" is a singleton shared across the suite, so each test resets
+    # it explicitly rather than unwinding through remove_service(): with the bug
+    # present, ids collide and "_services" loses entries, so an unwind leaves
+    # "service_count" drifted and later tests fail for the wrong reason
+    process = aiko.process
+    process._services.clear()
+    process.service_count = 0
+    process._service_id_last = 0
+    return process
+
+
+def test_service_ids_are_distinct_without_removals():
+    # Control: if this ever fails, the tests below prove nothing
+    process = _fresh_process()
+    a, b = ServiceStub("a"), ServiceStub("b")
+    process.add_service(a)
+    process.add_service(b)
+
+    assert a.service_id != b.service_id
+    assert a.topic_path != b.topic_path
+
+
+def test_service_id_not_reused_after_remove():
+    process = _fresh_process()
+    a, b = ServiceStub("a"), ServiceStub("b")
+    process.add_service(a)
+    process.add_service(b)
+
+    process.remove_service(a.service_id)  # remove the NON-last Service
+
+    c = ServiceStub("c")
+    process.add_service(c)
+
+    assert c.service_id != b.service_id, \
+        "new Service reused the id of a live Service"
+    assert c.topic_path != b.topic_path, \
+        "two live Services share a topic_path"
+
+
+def test_live_service_survives_a_later_add():
+    process = _fresh_process()
+    a, b = ServiceStub("a"), ServiceStub("b")
+    process.add_service(a)
+    process.add_service(b)
+    process.remove_service(a.service_id)
+    process.add_service(ServiceStub("c"))
+
+    assert b in process._services.values(), \
+        "a live Service was evicted from _services by a later add_service()"
+
+
+def test_service_count_still_tracks_live_services():
+    # The allocator changed; the public return value must not
+    process = _fresh_process()
+    a = ServiceStub("a")
+
+    assert process.add_service(a) == 1
+    assert process.add_service(ServiceStub("b")) == 2
+    assert process.remove_service(a.service_id) == 1

--- a/src/aiko_services/tests/unit/test_process.py
+++ b/src/aiko_services/tests/unit/test_process.py
@@ -22,14 +22,17 @@
 # ~~~~~
 # - None, yet !
 
+import pytest
+
 import aiko_services as aiko
+from aiko_services.main.connection import Connection, ConnectionState
+from aiko_services.main.process import ProcessImplementation
 
 
 class ServiceStub:
     # A payload, not a Service: these tests exercise the allocator in
     # add_service() / remove_service(), which never inspects the object beyond
-    # "protocol". "protocol" is None so the Registrar publish is skipped, and
-    # no broker is needed
+    # "protocol"
     def __init__(self, label):
         self.label = label
         self.service_id = None
@@ -37,21 +40,33 @@ class ServiceStub:
         self.protocol = None
 
 
-def _fresh_process():
-    # "aiko.process" is a singleton shared across the suite, so each test resets
-    # it explicitly rather than unwinding through remove_service(): with the bug
-    # present, ids collide and "_services" loses entries, so an unwind leaves
-    # "service_count" drifted and later tests fail for the wrong reason
-    process = aiko.process
-    process._services.clear()
-    process.service_count = 0
-    process._service_id_last = 0
+@pytest.fixture
+def process():
+    # A private ProcessImplementation, never the "aiko.process" singleton that
+    # the rest of the suite shares. ProcessImplementation.__init__() only
+    # assigns attributes, so an instance that initialize() never touched has its
+    # own "_services", counters and lock, and nothing here has to be put back.
+    #
+    # "connection" is a ProcessData CLASS attribute, so a new instance still
+    # shares the singleton's Connection. Give this one its own, which starts at
+    # ConnectionState.NONE: add_service() and remove_service() then always skip
+    # the Registrar publish, whatever the environment, rather than depending on
+    # every stub remembering to leave "protocol" as None
+    process = ProcessImplementation()
+    process.connection = Connection("test_process")
     return process
 
 
-def test_service_ids_are_distinct_without_removals():
+def test_the_fixture_is_isolated_from_the_singleton(process):
+    # Control: if the fixture is not isolated, the tests below are mutating
+    # shared state and their results say nothing about the allocator
+    assert process is not aiko.process
+    assert process._services is not aiko.process._services
+    assert not process.connection.is_connected(ConnectionState.REGISTRAR)
+
+
+def test_service_ids_are_distinct_without_removals(process):
     # Control: if this ever fails, the tests below prove nothing
-    process = _fresh_process()
     a, b = ServiceStub("a"), ServiceStub("b")
     process.add_service(a)
     process.add_service(b)
@@ -60,8 +75,7 @@ def test_service_ids_are_distinct_without_removals():
     assert a.topic_path != b.topic_path
 
 
-def test_service_id_not_reused_after_remove():
-    process = _fresh_process()
+def test_service_id_not_reused_after_remove(process):
     a, b = ServiceStub("a"), ServiceStub("b")
     process.add_service(a)
     process.add_service(b)
@@ -77,8 +91,7 @@ def test_service_id_not_reused_after_remove():
         "two live Services share a topic_path"
 
 
-def test_live_service_survives_a_later_add():
-    process = _fresh_process()
+def test_live_service_survives_a_later_add(process):
     a, b = ServiceStub("a"), ServiceStub("b")
     process.add_service(a)
     process.add_service(b)
@@ -89,9 +102,8 @@ def test_live_service_survives_a_later_add():
         "a live Service was evicted from _services by a later add_service()"
 
 
-def test_service_count_still_tracks_live_services():
+def test_service_count_still_tracks_live_services(process):
     # The allocator changed; the public return value must not
-    process = _fresh_process()
     a = ServiceStub("a")
 
     assert process.add_service(a) == 1

--- a/src/aiko_services/tests/unit/test_process.py
+++ b/src/aiko_services/tests/unit/test_process.py
@@ -102,6 +102,25 @@ def test_live_service_survives_a_later_add(process):
         "a live Service was evicted from _services by a later add_service()"
 
 
+def test_ids_are_not_reused_after_every_service_is_removed(process):
+    # The gap is deliberate. Remove every Service and the next id is still the
+    # next one up, never 1 again, so a Service that outlives its Process's
+    # registry entry can never be confused with a later arrival. Pinned here so
+    # a later reader does not "repair" the gap as an accident
+    a = ServiceStub("a")
+    process.add_service(a)
+    process.remove_service(a.service_id)
+
+    assert process.service_count == 0, "no live Services remain"
+
+    b = ServiceStub("b")
+    process.add_service(b)
+
+    assert b.service_id != a.service_id, \
+        "the allocator restarted after the registry emptied"
+    assert b.service_id == a.service_id + 1
+
+
 def test_service_count_still_tracks_live_services(process):
     # The allocator changed; the public return value must not
     a = ServiceStub("a")


### PR DESCRIPTION
Hi Andy!

`service_count` in `process.py` is doing two jobs: the live count of Services, which `remove_service()` decrements, and the allocator for `service_id`, which must never repeat while a Service still holds one.

So removing a non-last Service and adding another reissues a live id. Measured against `master` before changing anything, with stub payloads (no broker needed, `protocol` is `None` so the Registrar publish is skipped):

```
adds only          A(id=1)                     B(id=2)                     distinct
remove A, add C    B(id=2, aiko/host/44886/2)  C(id=2, aiko/host/44886/2)  collision
                   registry[2] is now C; B is gone from _services
```

The evicted Service stays registered with the Registrar under a `topic_path` it now shares, keeps its message handlers, and a later `remove_service()` on that id removes the wrong one.

Reachable through `hyperspace.py:296`, which calls `remove_service()` when an empty Category is destroyed. So: create Category A, create Category B, destroy A, create C.

The fix adds `_service_id_last`, which only ever increases, and leaves `service_count` as the live count. **The values both methods return are unchanged**, so nothing reading them changes meaning.

## Tests

`tests/unit/test_process.py`. Three arms fail without the fix: id reuse, a live Service evicted from `_services`, and the allocator restarting once the registry empties. Three controls stay green either way: ids distinct without removals, `service_count` still tracking live Services, and the fixture being isolated from the `aiko.process` singleton.

Every one of those six was checked by reverting the allocator and confirming the three arms go red with their intended messages while the three controls stay green. Full unit suite: 31 passed.

The tests use a private `ProcessImplementation()` rather than the `aiko.process` singleton, with its own `Connection` starting at `ConnectionState.NONE`, so the Registrar publish is always skipped whatever the environment, rather than depending on each stub leaving `protocol` as `None`.

## Scope of the guarantee

This gives uniqueness among live Services **within one Process lifetime**. `_service_id_last` is in memory and resets when a new `ProcessImplementation` is created, so the `pid` segment of `namespace/hostname/pid/service_id` still separates generations, exactly as before. It is not the frozen, registry-recorded identity that ADR-003 defines for HyperSpace and Storage UIDs, and `service_id` is a different address space from those.

## One thing this exposes, in another file

`dashboard.py:419` `_filter()` treats `service_id == "1"` as a Process's principal Service and resets `parent` on it, and both render loops initialise `parent` once and carry it across Services from different Processes. Previously a Process that lost its sid-1 Service would eventually reissue id 1, so `parent` got reset again. With a monotonic allocator it never does, so `parent` can stay stale from the previous Process for the rest of the render.

The bug is pre-existing and display only, and the old self-healing worked by handing a live Service's identity to a new one, which is the thing being fixed here. I have left `dashboard.py` alone rather than widen this change. Resetting `parent` per Process (`topic_path.topic_path_process`) instead of on the magic `"1"` looks like the right fix if you want it.

Happy to rework the shape if you would rather allocate ids differently, or if reuse after removal was intentional and the eviction is the only part you want fixed.

🤖 (generated) 🧑‍💻 (reviewed)
