### PR TITLE
Documentation: name the methods that the code defines

### DIFF
--- a/documentation/concepts/registrar.md
+++ b/documentation/concepts/registrar.md
@@ -237,9 +237,9 @@ Key design points:
 - `on_enter_primary()` wraps LWT installation in `try/except SystemError`
   — if the MQTT server is unavailable the transition rolls back through
   `primary_failed`.
-- `_service_add()` ignores duplicate `add`s for a known `topic_path`, and
-  re-publishes the *original inbound payload* on `topic_out` rather than
-  regenerating it.
+- `service_add()` ignores duplicate `add`s for a known `topic_path`, and
+  publishes canonical `generate()` output on `topic_out`, not a
+  byte-for-byte echo of the payload of the client.
 - Timestamps (`time_add`, `time_remove`, and the boot announcement's
   `TIME_STARTED`) use `time.monotonic()` — meaningful for ordering within
   a host, not wall-clock time.
@@ -266,7 +266,7 @@ From the source `To Do` list — highlights (the source marks several as
   Registrar from ever becoming primary
 - **BUG**: with multiple secondaries, when the primary fails *all*
   secondaries promote themselves to primary
-- **BUG** (noted at `_service_remove()`): process-level removal of all of
+- **BUG** (noted at `service_remove()`): process-level removal of all of
   a process's Services needs review. Also `service_count` should be
   coerced with `int()` when updated through ECProducer
 - `--primary` (forced take-over), `show`, `kill` CLI commands are

--- a/documentation/concepts/stream.md
+++ b/documentation/concepts/stream.md
@@ -276,7 +276,7 @@ do not need an explicit `create_stream`.
   `utilities/metrics.py`.
 - Source TODO checklists: verify StreamState `RUN | STOP | ERROR`
   behavior for both local and remote cases across
-  `_create_frame_generator()`, `create_stream()`,
+  `_create_frames_generator()`, `create_stream()`,
   `_process_frame_common()` and `destroy_stream()`. On generator
   `StreamEvent.ERROR`, destroy the Stream immediately (FIX note).
 - `Stream.set_state()` downgrade guard appears ineffective (see

--- a/src/aiko_services/main/pipeline.py
+++ b/src/aiko_services/main/pipeline.py
@@ -1547,17 +1547,17 @@ class PipelineImpl(Pipeline):
                 to_name = f"{out_element}.{to_name}"
                 frame_data_out[to_name] = frame_data_out.pop(from_name)
 
-# FIX: _create_frame_generator(): StreamEvent.ERROR -->
+# FIX: _create_frames_generator(): StreamEvent.ERROR -->
 #          self.destroy_stream(get_stream_id(), graceful=False)  # immediately !
 
 # TODO: Check local cases "stream_state.RUN | STOP | ERROR" ...
-# TODO: - _create_frame_generator()
+# TODO: - _create_frames_generator()
 # TODO: - create_stream()
 # TODO: - _process_frame_common()
 # TODO: - destroy_stream()
 
 # TODO: Check remote cases "stream_state.RUN | STOP | ERROR" ...
-# TODO: - _create_frame_generator()
+# TODO: - _create_frames_generator()
 # TODO: - create_stream()
 # TODO: - _process_frame_common()
 # TODO: - destroy_stream()

--- a/src/aiko_services/tests/unit/test_stream_event.py
+++ b/src/aiko_services/tests/unit/test_stream_event.py
@@ -12,7 +12,7 @@
 # ~~~~~
 # - Improve Aiko Services Process exit
 # - Test StreamEvent.OKAY, StreamEvent.STOP, StreamEvent.ERROR for ...
-#   - create_stream, _create_frame_generator, process_frame, destroy_stream
+#   - create_stream, _create_frames_generator, process_frame, destroy_stream
 #   - Consolidate any overlap with "test_stream_lock.py" ?
 
 from typing import Tuple

--- a/src/aiko_services/tests/unit/test_stream_lock.py
+++ b/src/aiko_services/tests/unit/test_stream_lock.py
@@ -11,7 +11,7 @@
 # - Improve Aiko Services Process exit
 #
 # - Test StreamEvent.OKAY, StreamEvent.STOP, StreamEvent.ERROR for ...
-#   - create_stream, _create_frame_generator, process_frame, destroy_stream
+#   - create_stream, _create_frames_generator, process_frame, destroy_stream
 #   - Consolidate any overlap with "test_stream_event.py" ?
 
 import threading


### PR DESCRIPTION
Three documented names have no definition in `src/`. Each is a name that moved and left the document behind.

## `_service_add()` / `_service_remove()` → `service_add()` / `service_remove()`

Renamed to the public form at `e5546b2`. `documentation/release_notes.md:122` records that rename, and the next release note records that the republished `(add ...)` payload became canonical `generate()` output rather than an echo of the payload of the client.

`documentation/concepts/registrar.md` kept both the old private names **and** the old payload behavior, so it disagreed with the code (`registrar.py:353`, which calls `generate()`) and with the release notes of the same repository. Both are corrected.

The release note itself is correct history and is unchanged.

## `_create_frame_generator()` → `_create_frames_generator()`

The function is plural at `pipeline.py:485`. The singular form appears in six places: `stream.md:279`, two test file headers, and three source comments. All six are corrected. Comments only, so no behavior changes.

No overlap with open PR #71, which touches `pipeline.py` at lines 493 and 517.

## How they were found

Every backticked identifier in `documentation/` compared against every `def` in `src/`: 363 documented names against 705 definitions, giving five names with no definition.

Two of the five are correct as they stand. `_image_convert()` is a proposed function in a To Do list, in both the document and the source.

The fifth, `_cleanup_locked()`, is a method of a `ThreadManager` class that `src/` does not contain — along with the `metrics`, `probe` and `thread` concept documents. Three of the fourteen documented utility modules have no module. That is larger than a name, so it is reported separately rather than patched here.

## Verification

- Unit tests: 25 passed
- `asd_ste100_lint.py` on both changed documents: `L=0 S=0 B=0 W=0 X=0 C=0 F=0`
- Lint positive control (a document with deliberately bad prose): `L=1 B=2 W=1`, which shows the lint can report findings

🤖 (generated) 🧑‍💻 (reviewed)