### PR TITLE
fix(dashboard): hold the parent of each Process, not one parent for the list

### DIFF
--- a/src/aiko_services/main/dashboard.py
+++ b/src/aiko_services/main/dashboard.py
@@ -426,9 +426,9 @@ class DashboardFrame(FrameCommon, asciimatics_Frame):
         # list holds the Services of all Processes, in no Process order.
         # A Process with no Service 1 has no parent, because "service_id"
         # comes from a counter that only increases.
-        # A Process key is "namespace/hostname/pid" and the history outlives a
-        # Process, so a reused process id puts two Processes under one key and
-        # the last one in the list wins
+        # Only for the live Services, where a process id belongs to one
+        # Process. The history needs the order sensitive form, and builds its
+        # own parents as it walks
         parents = {}
         for service in services:
             topic_path = aiko.ServiceTopicPath.parse(service[0])
@@ -612,13 +612,22 @@ class DashboardFrame(FrameCommon, asciimatics_Frame):
             for row_index, variable in enumerate(variables)
         ]
 
+        # The history keeps the Services of Processes that have stopped, and a
+        # Process key is "namespace/hostname/pid", so one key holds more than
+        # one Process once an operating system reuses a process id. Collect the
+        # parents as the list is walked, so each Service is judged by the
+        # Service 1 of its own Process most recently seen before it, and a
+        # later Process on the same key does not reach back over an earlier one
         service_history = list(self.services_cache.get_history())
-        parents = self._service_parents(service_history)
+        parents = {}
         services_formatted = []
         for service in service_history:
             topic_path = aiko.ServiceTopicPath.parse(service[0])
             topic_terse = topic_path.terse
             protocol = self._short_name(service[2])
+            if topic_path.service_id == "1":
+                parents[topic_path.topic_path_process] =  \
+                    self._protocol_base(protocol)
             show = self._filter(parents, topic_path, protocol)
             if show:
                 services_formatted.append(

--- a/src/aiko_services/main/dashboard.py
+++ b/src/aiko_services/main/dashboard.py
@@ -426,14 +426,23 @@ class DashboardFrame(FrameCommon, asciimatics_Frame):
         # list holds the Services of all Processes, in no Process order.
         # A Process with no Service 1 has no parent, because "service_id"
         # comes from a counter that only increases.
-        # Order independent on purpose: Service 1 does not have to arrive
-        # before the Services of its own Process
+        # Two Service 1 Services under one key are two Processes that an
+        # operating system gave the same process id, and nothing here says
+        # which Service belongs to which. That is less knowledge than one
+        # Service 1, not more, so the parent is unknown, the same as a Process
+        # with no Service 1 at all. Taking the last one would hide Services on
+        # the strength of where a Service sits in a list.
+        # So the answer never depends on the order of the list
         parents = {}
         for service in services:
             topic_path = aiko.ServiceTopicPath.parse(service[0])
             if topic_path.service_id == "1":
-                parents[topic_path.topic_path_process] =  \
-                    self._protocol_base(self._short_name(service[2]))
+                process = topic_path.topic_path_process
+                protocol = self._protocol_base(self._short_name(service[2]))
+                if process not in parents:
+                    parents[process] = protocol
+                elif parents[process] != protocol:
+                    parents[process] = None  # two Processes, one key
         return parents
 
     def _filter(self, parents, topic_path, protocol):

--- a/src/aiko_services/main/dashboard.py
+++ b/src/aiko_services/main/dashboard.py
@@ -426,9 +426,8 @@ class DashboardFrame(FrameCommon, asciimatics_Frame):
         # list holds the Services of all Processes, in no Process order.
         # A Process with no Service 1 has no parent, because "service_id"
         # comes from a counter that only increases.
-        # Only for the live Services, where a process id belongs to one
-        # Process. The history needs the order sensitive form, and builds its
-        # own parents as it walks
+        # Order independent on purpose: Service 1 does not have to arrive
+        # before the Services of its own Process
         parents = {}
         for service in services:
             topic_path = aiko.ServiceTopicPath.parse(service[0])
@@ -612,22 +611,21 @@ class DashboardFrame(FrameCommon, asciimatics_Frame):
             for row_index, variable in enumerate(variables)
         ]
 
-        # The history keeps the Services of Processes that have stopped, and a
-        # Process key is "namespace/hostname/pid", so one key holds more than
-        # one Process once an operating system reuses a process id. Collect the
-        # parents as the list is walked, so each Service is judged by the
-        # Service 1 of its own Process most recently seen before it, and a
-        # later Process on the same key does not reach back over an earlier one
+        # The history keeps the Services of Processes that have stopped, so one
+        # "namespace/hostname/pid" key can hold more than one Process once an
+        # operating system reuses a process id, and a Service carries nothing
+        # that says which one it belongs to. No rule over this list can
+        # separate them. The parents are collected in a pass of their own, the
+        # same as the live Services, because the list is written from both ends
+        # (share.py appendleft on removal, append for the Registrar history) so
+        # its order says nothing about when a Service ran
         service_history = list(self.services_cache.get_history())
-        parents = {}
+        parents = self._service_parents(service_history)
         services_formatted = []
         for service in service_history:
             topic_path = aiko.ServiceTopicPath.parse(service[0])
             topic_terse = topic_path.terse
             protocol = self._short_name(service[2])
-            if topic_path.service_id == "1":
-                parents[topic_path.topic_path_process] =  \
-                    self._protocol_base(protocol)
             show = self._filter(parents, topic_path, protocol)
             if show:
                 services_formatted.append(

--- a/src/aiko_services/main/dashboard.py
+++ b/src/aiko_services/main/dashboard.py
@@ -417,18 +417,17 @@ class DashboardFrame(FrameCommon, asciimatics_Frame):
         self.service_tags = None
 
     def _service_parents(self, services):
-        # The parent of a Process is its Service with "service_id" 1. Collect
-        # the parent of every Process before any Service is filtered: the
-        # Services of all Processes share one list, in no Process order, so a
-        # parent carried through the list belongs to whichever Process held the
-        # last Service 1, which is not always this Service's Process.
-        # A Process has no parent while it has no Service 1, and "service_id"
-        # comes from a counter that only increases, so Service 1 does not
-        # return after it is removed
+        # Collect every Process's parent before filtering any Service: one
+        # list holds the Services of all Processes, in no Process order.
+        # A Process with no Service 1 has no parent, because "service_id"
+        # comes from a counter that only increases.
+        # A Process key is "namespace/hostname/pid" and the history outlives a
+        # Process, so a reused process id puts two Processes under one key and
+        # the last one in the list wins
         parents = {}
         for service in services:
             topic_path = aiko.ServiceTopicPath.parse(service[0])
-            if topic_path and topic_path.service_id == "1":
+            if topic_path.service_id == "1":
                 parents[topic_path.topic_path_process] =  \
                     self._short_name(service[2]).split(":")[0]
         return parents

--- a/src/aiko_services/main/dashboard.py
+++ b/src/aiko_services/main/dashboard.py
@@ -416,6 +416,11 @@ class DashboardFrame(FrameCommon, asciimatics_Frame):
         self.service_cache = {}
         self.service_tags = None
 
+    def _protocol_base(self, protocol):
+        # The parent pass and the filter must reduce a protocol the same way.
+        # One function, so that is mechanical rather than a shared habit
+        return protocol.split(":")[0]
+
     def _service_parents(self, services):
         # Collect every Process's parent before filtering any Service: one
         # list holds the Services of all Processes, in no Process order.
@@ -429,11 +434,11 @@ class DashboardFrame(FrameCommon, asciimatics_Frame):
             topic_path = aiko.ServiceTopicPath.parse(service[0])
             if topic_path.service_id == "1":
                 parents[topic_path.topic_path_process] =  \
-                    self._short_name(service[2]).split(":")[0]
+                    self._protocol_base(self._short_name(service[2]))
         return parents
 
     def _filter(self, parents, topic_path, protocol):
-        protocol = protocol.split(":")[0]
+        protocol = self._protocol_base(protocol)
 
         show = protocol not in self.filter_out
         if topic_path.service_id != "1":

--- a/src/aiko_services/main/dashboard.py
+++ b/src/aiko_services/main/dashboard.py
@@ -416,19 +416,34 @@ class DashboardFrame(FrameCommon, asciimatics_Frame):
         self.service_cache = {}
         self.service_tags = None
 
-    def _filter(self, parent, service, topic_path, protocol):
+    def _service_parents(self, services):
+        # The parent of a Process is its Service with "service_id" 1. Collect
+        # the parent of every Process before any Service is filtered: the
+        # Services of all Processes share one list, in no Process order, so a
+        # parent carried through the list belongs to whichever Process held the
+        # last Service 1, which is not always this Service's Process.
+        # A Process has no parent while it has no Service 1, and "service_id"
+        # comes from a counter that only increases, so Service 1 does not
+        # return after it is removed
+        parents = {}
+        for service in services:
+            topic_path = aiko.ServiceTopicPath.parse(service[0])
+            if topic_path and topic_path.service_id == "1":
+                parents[topic_path.topic_path_process] =  \
+                    self._short_name(service[2]).split(":")[0]
+        return parents
+
+    def _filter(self, parents, topic_path, protocol):
         protocol = protocol.split(":")[0]
-        if topic_path.service_id == "1":
-            parent = (topic_path, protocol)
 
         show = protocol not in self.filter_out
         if topic_path.service_id != "1":
             if "sid>1" in self.filter_out:
                 show = False
             if "pipeline_element" in self.filter_out and  \
-                parent[1] and parent[1] == "pipeline":
+                parents.get(topic_path.topic_path_process) == "pipeline":
                 show = False
-        return parent, show
+        return show
 
     def _get_service_topic_path_next(self):
         service_topic_path_next = None
@@ -549,16 +564,16 @@ class DashboardFrame(FrameCommon, asciimatics_Frame):
         if self.adjust_palette_required:
             self._adjust_palette()
 
-        parent = (None, None)
         services_count = self.services_cache.get_services().count   # correct
         services = self.services_cache.get_services().copy()  # count is zero
+        parents = self._service_parents(services)
         services_formatted = []
         for service in services:
             topic_path = aiko.ServiceTopicPath.parse(service[0])
             topic_color = self._service_selection_color(
                 self.YELLOW, str(topic_path), topic_path.terse)
             protocol = self._short_name(service[2])
-            parent, show = self._filter(parent, service, topic_path, protocol)
+            show = self._filter(parents, topic_path, protocol)
             if show:
                 services_formatted.append(
                     (topic_color, service[1], service[4], protocol, service[3]))
@@ -593,14 +608,14 @@ class DashboardFrame(FrameCommon, asciimatics_Frame):
             for row_index, variable in enumerate(variables)
         ]
 
-        parent = (None, None)
         service_history = list(self.services_cache.get_history())
+        parents = self._service_parents(service_history)
         services_formatted = []
         for service in service_history:
             topic_path = aiko.ServiceTopicPath.parse(service[0])
             topic_terse = topic_path.terse
             protocol = self._short_name(service[2])
-            parent, show = self._filter(parent, service, topic_path, protocol)
+            show = self._filter(parents, topic_path, protocol)
             if show:
                 services_formatted.append(
                     (topic_terse, service[1], service[4], protocol, service[3]))

--- a/src/aiko_services/tests/unit/test_dashboard_filter.py
+++ b/src/aiko_services/tests/unit/test_dashboard_filter.py
@@ -69,23 +69,6 @@ def _shown(dashboard, services):
     return shown
 
 
-def _shown_history(dashboard, services):
-    # Mirror the history loop: collect the parents while walking, so a Service
-    # is judged by the Service 1 of its own Process most recently seen before
-    # it. Returns indexes, because the history repeats a topic path
-    parents = {}
-    shown = []
-    for index, service in enumerate(services):
-        topic_path = ServiceTopicPath.parse(service[0])
-        protocol = dashboard._short_name(service[2])
-        if topic_path.service_id == "1":
-            parents[topic_path.topic_path_process] =  \
-                dashboard._protocol_base(protocol)
-        if dashboard._filter(parents, topic_path, protocol):
-            shown.append(index)
-    return shown
-
-
 def test_the_pipeline_element_filter_still_hides_its_own_pipelines_elements():
     # Control: if this fails, the filter is broken outright and the test below
     # proves nothing
@@ -146,37 +129,26 @@ def test_both_passes_reduce_a_protocol_the_same_way():
         dashboard._protocol_base(dashboard._short_name(service[2]))
 
 
-def test_history_judges_each_process_lifetime_by_its_own_service_1():
-    # A Process key is "namespace/hostname/pid" and the history outlives a
-    # Process, so one key holds more than one Process once an operating system
-    # reuses a process id. Here pid 100 is an Actor Process, and later a
-    # Pipeline Process. Only the Services of the Pipeline lifetime may be
-    # hidden by the "pipeline_element" filter. A parent collected for the whole
-    # list instead of while walking it reaches back over the earlier lifetime
-    # and hides row 1 as well
+def test_a_process_id_used_by_two_processes_cannot_be_separated():
+    # Recorded so the limit is explicit rather than discovered. The history
+    # keeps the Services of Processes that have stopped, so one
+    # "namespace/hostname/pid" key can hold more than one Process once an
+    # operating system reuses a process id. A Service carries its topic path
+    # and its protocol, and nothing that says which Process it belonged to, so
+    # the two lifetimes are one Process here. The parent of the last Service 1
+    # in the list is used for both, and the answer does not depend on the order
+    # of the list, which is what this asserts. Separating them needs something
+    # on the Service that this list does not carry
     dashboard = _dashboard(["pipeline_element"])
-    history = [
-        _service(f"{PROCESS_A}/1", ACTOR),     # the Actor Process
-        _service(f"{PROCESS_A}/2", ACTOR),     # its Service 2, must be shown
-        _service(f"{PROCESS_A}/1", PIPELINE),  # the Process that reused the id
-        _service(f"{PROCESS_A}/2", ACTOR),     # its Service 2, must be hidden
-    ]
+    first = _service(f"{PROCESS_A}/1", ACTOR)
+    second = _service(f"{PROCESS_A}/1", PIPELINE)
+    element = _service(f"{PROCESS_A}/2", ACTOR)
 
-    assert _shown_history(dashboard, history) == [0, 1, 2], \
-        "a later Process on a reused id changed the parent of an earlier one"
+    forwards = dashboard._service_parents([first, second, element])
+    backwards = dashboard._service_parents([element, first, second])
 
-
-def test_history_still_scopes_a_parent_to_its_own_process():
-    # The defect this change fixes, in the history view: Process B has no
-    # Service 1, so it has no parent and must not take the parent of Process A
-    dashboard = _dashboard(["pipeline_element"])
-    history = [
-        _service(f"{PROCESS_A}/1", PIPELINE),
-        _service(f"{PROCESS_B}/2", ACTOR),
-    ]
-
-    assert 1 in _shown_history(dashboard, history), \
-        "a Process with no Service 1 inherited another Process's parent"
+    assert forwards == backwards, \
+        "the parent of a Process depended on the order of the list"
 
 
 def test_service_1_is_never_hidden_by_the_sid_filter():

--- a/src/aiko_services/tests/unit/test_dashboard_filter.py
+++ b/src/aiko_services/tests/unit/test_dashboard_filter.py
@@ -1,0 +1,119 @@
+# Usage
+# ~~~~~
+# pytest [-s] unit/test_dashboard_filter.py
+# pytest [-s] unit/test_dashboard_filter.py::test_a_process_without_service_id_1
+#
+# Regression tests for the Service list filter in "dashboard.py".
+#
+# The Dashboard groups a Process's Services under the Service that holds
+# "service_id" 1, and the "pipeline_element" filter hides the other Services of
+# a Process whose Service 1 is a Pipeline.
+#
+# The bug these cover: the parent was carried through one loop across every
+# Service in the list, and the list holds the Services of all Processes. The
+# parent changed only when a Service with "service_id" 1 was found, so a Process
+# that has no Service 1 used the previous Process's parent, and the filter then
+# applied one Process's protocol to a different Process's Services.
+#
+# A Process can have no Service 1 whenever Service 1 is removed, because
+# "service_id" is allocated from a counter that only increases.
+#
+# To Do
+# ~~~~~
+# - None, yet !
+
+import types
+
+from aiko_services.main.dashboard import DashboardFrame
+from aiko_services.main.service import ServiceTopicPath
+
+PIPELINE = "github.com/geekscape/aiko_services/protocol/pipeline:0"
+ELEMENT = "github.com/geekscape/aiko_services/protocol/pipeline_element:0"
+ACTOR = "github.com/geekscape/aiko_services/protocol/actor:0"
+
+PROCESS_A = "aiko/host/100"
+PROCESS_B = "aiko/host/200"
+
+
+def _service(topic_path, protocol):
+    # Only fields 0 and 2 are read by the filter
+    return (topic_path, "name", protocol, "transport", "owner")
+
+
+def _dashboard(filter_out):
+    # The filter reads "self.filter_out" and calls "self._short_name()", and
+    # nothing else, so it runs without a Screen or a Frame
+    return types.SimpleNamespace(
+        filter_out=set(filter_out),
+        _short_name=DashboardFrame._short_name.__get__(object()),
+    )
+
+
+def _shown(dashboard, services):
+    # Mirror the render loops: build the parents once, then filter each Service
+    parents = DashboardFrame._service_parents(dashboard, services)
+    shown = []
+    for service in services:
+        topic_path = ServiceTopicPath.parse(service[0])
+        protocol = dashboard._short_name(service[2])
+        if DashboardFrame._filter(dashboard, parents, topic_path, protocol):
+            shown.append(service[0])
+    return shown
+
+
+def test_the_pipeline_element_filter_still_hides_its_own_pipelines_elements():
+    # Control: if this fails, the filter is broken outright and the test below
+    # proves nothing
+    dashboard = _dashboard(["pipeline_element"])
+    services = [
+        _service(f"{PROCESS_A}/1", PIPELINE),
+        _service(f"{PROCESS_A}/2", ELEMENT),
+    ]
+
+    assert _shown(dashboard, services) == [f"{PROCESS_A}/1"]
+
+
+def test_a_process_without_service_id_1_is_not_given_another_process_parent():
+    # Process B has no Service 1, so it has no parent and no Pipeline, and its
+    # Services must not be hidden by Process A being a Pipeline
+    dashboard = _dashboard(["pipeline_element"])
+    services = [
+        _service(f"{PROCESS_A}/1", PIPELINE),
+        _service(f"{PROCESS_A}/2", ELEMENT),
+        _service(f"{PROCESS_B}/2", ACTOR),  # Service 1 was removed
+    ]
+
+    assert f"{PROCESS_B}/2" in _shown(dashboard, services), \
+        "a Process with no Service 1 inherited another Process's parent"
+
+
+def test_the_result_does_not_depend_on_the_order_of_the_services():
+    # The same three Services, with Process B first. If the parent is carried
+    # through the list rather than held per Process, these two orders disagree,
+    # which is the defect stated as a property
+    dashboard = _dashboard(["pipeline_element"])
+    a1 = _service(f"{PROCESS_A}/1", PIPELINE)
+    a2 = _service(f"{PROCESS_A}/2", ELEMENT)
+    b2 = _service(f"{PROCESS_B}/2", ACTOR)
+
+    assert sorted(_shown(dashboard, [a1, a2, b2])) == \
+           sorted(_shown(dashboard, [b2, a1, a2]))
+
+
+def test_service_1_is_never_hidden_by_the_sid_filter():
+    dashboard = _dashboard(["sid>1"])
+    services = [
+        _service(f"{PROCESS_A}/1", PIPELINE),
+        _service(f"{PROCESS_A}/2", ELEMENT),
+    ]
+
+    assert _shown(dashboard, services) == [f"{PROCESS_A}/1"]
+
+
+def test_a_protocol_in_filter_out_is_hidden_whatever_its_parent():
+    dashboard = _dashboard(["actor"])
+    services = [
+        _service(f"{PROCESS_B}/2", ACTOR),
+    ]
+
+    assert _shown(dashboard, services) == []

--- a/src/aiko_services/tests/unit/test_dashboard_filter.py
+++ b/src/aiko_services/tests/unit/test_dashboard_filter.py
@@ -140,24 +140,39 @@ def test_where_a_service_1_sits_does_not_change_the_answer():
            dashboard._service_parents([element, parent])
 
 
-def test_two_processes_on_one_id_are_decided_by_list_order():
-    # The limit, stated as it really is rather than better than it is.
+def test_two_processes_on_one_id_have_no_parent_either_way():
     # The history keeps the Services of Processes that have stopped, so one
     # "namespace/hostname/pid" key can hold more than one Process once an
-    # operating system reuses a process id, and a Service carries nothing that
-    # says which one it belonged to. The last Service 1 in the list wins, so
-    # for this case, and only this case, the answer follows the order of the
-    # list. "share.py" writes the history from both ends, so that order is not
-    # defined, which makes the winner arbitrary. Separating them needs
-    # something on the Service that the list does not carry
+    # operating system reuses a process id. Two Service 1 Services under one
+    # key is less knowledge than one, not more, so the parent is unknown, and
+    # the Services are shown rather than hidden on the strength of which
+    # Service 1 happened to come last. "share.py" writes the history from both
+    # ends, so that order is not defined and must not decide what is displayed
     dashboard = _dashboard(["pipeline_element"])
     actor_1 = _service(f"{PROCESS_A}/1", ACTOR)
     pipeline_1 = _service(f"{PROCESS_A}/1", PIPELINE)
+    element = _service(f"{PROCESS_A}/2", ACTOR)
 
-    assert dashboard._service_parents([actor_1, pipeline_1]) ==  \
-        {PROCESS_A: "pipeline"}
-    assert dashboard._service_parents([pipeline_1, actor_1]) ==  \
-        {PROCESS_A: "actor"}
+    forwards = [actor_1, pipeline_1, element]
+    backwards = [pipeline_1, actor_1, element]
+
+    assert dashboard._service_parents(forwards) == {PROCESS_A: None}
+    assert dashboard._service_parents(backwards) == {PROCESS_A: None}
+    assert f"{PROCESS_A}/2" in _shown(dashboard, forwards)
+    assert f"{PROCESS_A}/2" in _shown(dashboard, backwards)
+
+
+def test_one_process_repeating_its_service_1_still_has_a_parent():
+    # Only a DIFFERENT protocol means two Processes. The same Service 1 listed
+    # twice is one Process, and its Services must still be filtered
+    dashboard = _dashboard(["pipeline_element"])
+    pipeline_1 = _service(f"{PROCESS_A}/1", PIPELINE)
+    element = _service(f"{PROCESS_A}/2", ACTOR)
+
+    services = [pipeline_1, pipeline_1, element]
+
+    assert dashboard._service_parents(services) == {PROCESS_A: "pipeline"}
+    assert f"{PROCESS_A}/2" not in _shown(dashboard, services)
 
 
 def test_service_1_is_never_hidden_by_the_sid_filter():

--- a/src/aiko_services/tests/unit/test_dashboard_filter.py
+++ b/src/aiko_services/tests/unit/test_dashboard_filter.py
@@ -44,6 +44,7 @@ class _Dashboard:
     # a Frame. Taken from DashboardFrame rather than copied, so this stub
     # cannot drift away from the code it stands in for
     _short_name = DashboardFrame._short_name
+    _protocol_base = DashboardFrame._protocol_base
     _service_parents = DashboardFrame._service_parents
     _filter = DashboardFrame._filter
 
@@ -104,6 +105,27 @@ def test_the_result_does_not_depend_on_the_order_of_the_services():
 
     assert sorted(_shown(dashboard, [a1, a2, b2])) == \
            sorted(_shown(dashboard, [b2, a1, a2]))
+
+
+def test_an_empty_service_list_has_no_parents_and_shows_nothing():
+    # The Dashboard runs before any Service is registered, and the parent pass
+    # must not assume the list has anything in it
+    dashboard = _dashboard(["pipeline_element"])
+
+    assert dashboard._service_parents([]) == {}
+    assert _shown(dashboard, []) == []
+
+
+def test_both_passes_reduce_a_protocol_the_same_way():
+    # The parent pass stores a reduced protocol and the filter reduces the one
+    # it is given. If those two ever disagree, a Pipeline stops being
+    # recognised as a parent and the filter silently stops working
+    dashboard = _dashboard([])
+    service = _service(f"{PROCESS_A}/1", PIPELINE)
+
+    parents = dashboard._service_parents([service])
+    assert parents[PROCESS_A] ==  \
+        dashboard._protocol_base(dashboard._short_name(service[2]))
 
 
 def test_a_reused_process_id_takes_the_last_parent_in_the_list():

--- a/src/aiko_services/tests/unit/test_dashboard_filter.py
+++ b/src/aiko_services/tests/unit/test_dashboard_filter.py
@@ -22,8 +22,6 @@
 # ~~~~~
 # - None, yet !
 
-import types
-
 from aiko_services.main.dashboard import DashboardFrame
 from aiko_services.main.service import ServiceTopicPath
 
@@ -40,23 +38,31 @@ def _service(topic_path, protocol):
     return (topic_path, "name", protocol, "transport", "owner")
 
 
+class _Dashboard:
+    # The three methods under test read "self.filter_out" and call
+    # "self._short_name()", and nothing else, so they run without a Screen or
+    # a Frame. Taken from DashboardFrame rather than copied, so this stub
+    # cannot drift away from the code it stands in for
+    _short_name = DashboardFrame._short_name
+    _service_parents = DashboardFrame._service_parents
+    _filter = DashboardFrame._filter
+
+    def __init__(self, filter_out):
+        self.filter_out = set(filter_out)
+
+
 def _dashboard(filter_out):
-    # The filter reads "self.filter_out" and calls "self._short_name()", and
-    # nothing else, so it runs without a Screen or a Frame
-    return types.SimpleNamespace(
-        filter_out=set(filter_out),
-        _short_name=DashboardFrame._short_name.__get__(object()),
-    )
+    return _Dashboard(filter_out)
 
 
 def _shown(dashboard, services):
     # Mirror the render loops: build the parents once, then filter each Service
-    parents = DashboardFrame._service_parents(dashboard, services)
+    parents = dashboard._service_parents(services)
     shown = []
     for service in services:
         topic_path = ServiceTopicPath.parse(service[0])
         protocol = dashboard._short_name(service[2])
-        if DashboardFrame._filter(dashboard, parents, topic_path, protocol):
+        if dashboard._filter(parents, topic_path, protocol):
             shown.append(service[0])
     return shown
 
@@ -98,6 +104,24 @@ def test_the_result_does_not_depend_on_the_order_of_the_services():
 
     assert sorted(_shown(dashboard, [a1, a2, b2])) == \
            sorted(_shown(dashboard, [b2, a1, a2]))
+
+
+def test_a_reused_process_id_takes_the_last_parent_in_the_list():
+    # A Process key is "namespace/hostname/pid". The history outlives a
+    # Process, so an operating system that reuses a process id can put two
+    # Processes under one key, each with its own Service 1. The last one in
+    # the list wins. Pinned because it is a choice, not an accident, and
+    # because the alternative, the first one winning, is equally arguable
+    dashboard = _dashboard(["pipeline_element"])
+    services = [
+        _service(f"{PROCESS_A}/1", ACTOR),      # the Process that stopped
+        _service(f"{PROCESS_A}/1", PIPELINE),   # the Process that reused its id
+        _service(f"{PROCESS_A}/2", ELEMENT),
+    ]
+
+    parents = dashboard._service_parents(services)
+    assert parents[PROCESS_A] == "pipeline"
+    assert f"{PROCESS_A}/2" not in _shown(dashboard, services)
 
 
 def test_service_1_is_never_hidden_by_the_sid_filter():

--- a/src/aiko_services/tests/unit/test_dashboard_filter.py
+++ b/src/aiko_services/tests/unit/test_dashboard_filter.py
@@ -57,7 +57,8 @@ def _dashboard(filter_out):
 
 
 def _shown(dashboard, services):
-    # Mirror the render loops: build the parents once, then filter each Service
+    # Mirror the live Services loop: collect the parents once, so the answer
+    # does not depend on where a Service 1 sits in the list
     parents = dashboard._service_parents(services)
     shown = []
     for service in services:
@@ -65,6 +66,23 @@ def _shown(dashboard, services):
         protocol = dashboard._short_name(service[2])
         if dashboard._filter(parents, topic_path, protocol):
             shown.append(service[0])
+    return shown
+
+
+def _shown_history(dashboard, services):
+    # Mirror the history loop: collect the parents while walking, so a Service
+    # is judged by the Service 1 of its own Process most recently seen before
+    # it. Returns indexes, because the history repeats a topic path
+    parents = {}
+    shown = []
+    for index, service in enumerate(services):
+        topic_path = ServiceTopicPath.parse(service[0])
+        protocol = dashboard._short_name(service[2])
+        if topic_path.service_id == "1":
+            parents[topic_path.topic_path_process] =  \
+                dashboard._protocol_base(protocol)
+        if dashboard._filter(parents, topic_path, protocol):
+            shown.append(index)
     return shown
 
 
@@ -128,22 +146,37 @@ def test_both_passes_reduce_a_protocol_the_same_way():
         dashboard._protocol_base(dashboard._short_name(service[2]))
 
 
-def test_a_reused_process_id_takes_the_last_parent_in_the_list():
-    # A Process key is "namespace/hostname/pid". The history outlives a
-    # Process, so an operating system that reuses a process id can put two
-    # Processes under one key, each with its own Service 1. The last one in
-    # the list wins. Pinned because it is a choice, not an accident, and
-    # because the alternative, the first one winning, is equally arguable
+def test_history_judges_each_process_lifetime_by_its_own_service_1():
+    # A Process key is "namespace/hostname/pid" and the history outlives a
+    # Process, so one key holds more than one Process once an operating system
+    # reuses a process id. Here pid 100 is an Actor Process, and later a
+    # Pipeline Process. Only the Services of the Pipeline lifetime may be
+    # hidden by the "pipeline_element" filter. A parent collected for the whole
+    # list instead of while walking it reaches back over the earlier lifetime
+    # and hides row 1 as well
     dashboard = _dashboard(["pipeline_element"])
-    services = [
-        _service(f"{PROCESS_A}/1", ACTOR),      # the Process that stopped
-        _service(f"{PROCESS_A}/1", PIPELINE),   # the Process that reused its id
-        _service(f"{PROCESS_A}/2", ELEMENT),
+    history = [
+        _service(f"{PROCESS_A}/1", ACTOR),     # the Actor Process
+        _service(f"{PROCESS_A}/2", ACTOR),     # its Service 2, must be shown
+        _service(f"{PROCESS_A}/1", PIPELINE),  # the Process that reused the id
+        _service(f"{PROCESS_A}/2", ACTOR),     # its Service 2, must be hidden
     ]
 
-    parents = dashboard._service_parents(services)
-    assert parents[PROCESS_A] == "pipeline"
-    assert f"{PROCESS_A}/2" not in _shown(dashboard, services)
+    assert _shown_history(dashboard, history) == [0, 1, 2], \
+        "a later Process on a reused id changed the parent of an earlier one"
+
+
+def test_history_still_scopes_a_parent_to_its_own_process():
+    # The defect this change fixes, in the history view: Process B has no
+    # Service 1, so it has no parent and must not take the parent of Process A
+    dashboard = _dashboard(["pipeline_element"])
+    history = [
+        _service(f"{PROCESS_A}/1", PIPELINE),
+        _service(f"{PROCESS_B}/2", ACTOR),
+    ]
+
+    assert 1 in _shown_history(dashboard, history), \
+        "a Process with no Service 1 inherited another Process's parent"
 
 
 def test_service_1_is_never_hidden_by_the_sid_filter():

--- a/src/aiko_services/tests/unit/test_dashboard_filter.py
+++ b/src/aiko_services/tests/unit/test_dashboard_filter.py
@@ -129,26 +129,35 @@ def test_both_passes_reduce_a_protocol_the_same_way():
         dashboard._protocol_base(dashboard._short_name(service[2]))
 
 
-def test_a_process_id_used_by_two_processes_cannot_be_separated():
-    # Recorded so the limit is explicit rather than discovered. The history
-    # keeps the Services of Processes that have stopped, so one
-    # "namespace/hostname/pid" key can hold more than one Process once an
-    # operating system reuses a process id. A Service carries its topic path
-    # and its protocol, and nothing that says which Process it belonged to, so
-    # the two lifetimes are one Process here. The parent of the last Service 1
-    # in the list is used for both, and the answer does not depend on the order
-    # of the list, which is what this asserts. Separating them needs something
-    # on the Service that this list does not carry
+def test_where_a_service_1_sits_does_not_change_the_answer():
+    # The parent of a Process is collected before any Service is filtered, so
+    # Service 1 does not have to arrive before the Services of its own Process
     dashboard = _dashboard(["pipeline_element"])
-    first = _service(f"{PROCESS_A}/1", ACTOR)
-    second = _service(f"{PROCESS_A}/1", PIPELINE)
+    parent = _service(f"{PROCESS_A}/1", PIPELINE)
     element = _service(f"{PROCESS_A}/2", ACTOR)
 
-    forwards = dashboard._service_parents([first, second, element])
-    backwards = dashboard._service_parents([element, first, second])
+    assert dashboard._service_parents([parent, element]) ==  \
+           dashboard._service_parents([element, parent])
 
-    assert forwards == backwards, \
-        "the parent of a Process depended on the order of the list"
+
+def test_two_processes_on_one_id_are_decided_by_list_order():
+    # The limit, stated as it really is rather than better than it is.
+    # The history keeps the Services of Processes that have stopped, so one
+    # "namespace/hostname/pid" key can hold more than one Process once an
+    # operating system reuses a process id, and a Service carries nothing that
+    # says which one it belonged to. The last Service 1 in the list wins, so
+    # for this case, and only this case, the answer follows the order of the
+    # list. "share.py" writes the history from both ends, so that order is not
+    # defined, which makes the winner arbitrary. Separating them needs
+    # something on the Service that the list does not carry
+    dashboard = _dashboard(["pipeline_element"])
+    actor_1 = _service(f"{PROCESS_A}/1", ACTOR)
+    pipeline_1 = _service(f"{PROCESS_A}/1", PIPELINE)
+
+    assert dashboard._service_parents([actor_1, pipeline_1]) ==  \
+        {PROCESS_A: "pipeline"}
+    assert dashboard._service_parents([pipeline_1, actor_1]) ==  \
+        {PROCESS_A: "actor"}
 
 
 def test_service_1_is_never_hidden_by_the_sid_filter():


### PR DESCRIPTION
Hi Andy!

The Dashboard groups the Services of a Process under the Service holding `service_id` 1, and the `pipeline_element` filter hides the other Services of a Process whose Service 1 is a Pipeline.

The parent was a single variable carried through the loop, and that loop walks the Services of **every** Process. It only changed when a Service with `service_id` 1 appeared, so a Process with no Service 1 kept whichever Process came before it. The filter then tested the protocol of one Process to decide whether to hide the Services of a different Process.

A Process has no Service 1 whenever Service 1 is removed, which is reachable today through `hyperspace.py:296` when an empty Category is destroyed.

## The defect, measured

I ran the original `_filter()` and its loop against three Services: Process A with a Pipeline at Service 1 and an element at Service 2, and Process B with only a Service 2, with `pipeline_element` filtered out.

```
[a1, a2, b2] -> ["aiko/host/100/1"]                        B/2 hidden
[b2, a1, a2] -> ["aiko/host/100/1", "aiko/host/200/2"]     B/2 shown
```

The same three Services give a different display depending only on their order in the list. In the first order `aiko/host/200/2` is hidden because Process B inherited a Pipeline parent that it does not have.

## The change

`_service_parents()` collects the parent of every Process before any Service is filtered, and `_filter()` looks up the parent of the Process that owns the Service it is testing. A Process with no Service 1 has no parent, so its Services are shown, which is the right direction to fail for a display filter.

The `service_id` 1 rule is unchanged. It is what the user facing `sid>1` filter names, so this fixes **which Process the parent comes from**, and does not redefine which Service is the parent. If you would rather the parent became the lowest `service_id` in a Process, so that a Process keeps a parent after Service 1 is removed, that is a different decision and it is yours.

`_filter()` also loses its unused `service` parameter, and the parent is now the protocol alone, because the `topic_path` half of the old tuple was never read.

## Tests

`tests/unit/test_dashboard_filter.py` runs without a Screen or a Frame, because the filter reads only `self.filter_out` and `self._short_name()`.

Two arms state the defect, and both fail against the original `_filter()` and its loop rather than merely against a missing method: a Process with no Service 1 must not inherit the parent of another Process, and the visible set must not depend on the order of the list.

The rest hold either way, and say only what they prove: the elements of a Pipeline stay hidden, Service 1 is never hidden by `sid>1`, a protocol in `filter_out` is hidden whatever its parent, an empty list has no parents, both passes reduce a protocol identically, where a Service 1 sits does not change the answer, a key holding two Processes has no parent whichever order the list is in, and a Service 1 repeated for one Process is still a parent.

Unit tests: 35 passed. Each behaviour that could have been asserted loosely was checked against an implementation that gets it wrong: the arms against the original loop, the ambiguous-parent rule against last-wins, and the protocol reduction against a first-wins allocator.

I have not driven the live Dashboard, because that needs a broker and a terminal. The changed logic is covered directly, every caller is updated, and nothing subclasses or overrides `_filter()`.

## Two Processes on one process id

The live Services and the history are not equally decidable, and getting this right took several attempts.

For the live Services a Process key of `namespace/hostname/pid` is unambiguous, because a process id belongs to one Process at a time. Service 1 does not have to arrive first, so the parents are collected in a pass of their own.

The history keeps the Services of Processes that have stopped, so one key holds more than one Process once the operating system reuses a process id, and a history row carries its topic path and its protocol and nothing that says which Process it belonged to.

I first gave the history an order sensitive rule, judging a Service by the Service 1 of its own Process most recently seen before it. That was measured against a list in lifetime order, and the list is not in lifetime order: `share.py` writes it from both ends, `appendleft` for each Service as it is removed (`share.py:830`) and `append` for the batch the Registrar sends (`share.py:794`). Against the order it really produces, that rule is wrong in the same places master is wrong.

The rule now says that two different Service 1 Services under one key is **less** knowledge than one, not more. A Process with no Service 1 already has no parent and its Services are shown, because a display filter should fail towards showing rather than hide rows an operator cannot then miss. A key holding two Processes is that same absence of knowledge, so it is treated the same way, and the Services are shown.

That also removes the order question rather than documenting it:

```
[actor_1, pipeline_1]  ->  {"aiko/host/100": None}
[pipeline_1, actor_1]  ->  {"aiko/host/100": None}
```

The answer no longer depends on the order of the list, so the history being written from both ends stops mattering. Only a *different* protocol means two Processes; the same Service 1 listed twice is one Process and is still filtered.

If you would rather the history separated the two lifetimes properly, a row needs something it does not carry today. The Registrar already keeps `time_add` and `time_remove` for live entries, so carrying `time_add` into the history tuple would do it. That is your call and it is not in this change.

What this change fixes, in both lists, is the defect it was opened for: a Process with no Service 1 taking the parent of a different Process.

## On malformed topic paths

An earlier version of `_service_parents()` skipped a topic path that `ServiceTopicPath.parse()` returns `None` for. That was worse than it looked: the render loop two lines later dereferences the same value and raises `AttributeError`, so the helper appeared to handle a case the Dashboard does not handle. The guard is gone, and a malformed topic path now fails exactly as it failed before this branch. Whether the Dashboard should tolerate one at all is a separate question and it is yours.

## Related, not included

While confirming that the loop can iterate a `Services` twice safely, I found that `ServicesIterator` in `service.py` has `__next__` but no `__iter__`. A plain `for`, and `list()`, `sorted()` and `tuple()`, all work. A comprehension or a generator expression over a non-empty `Services` raises `TypeError: 'ServicesIterator' object is not iterable`. No shipped call site does that, so it is latent. Different file, different defect, so I left it out. Happy to send it separately if you want it.

This is independent of #97, although #97 is what led me to look here. With `service_id` allocated monotonically, a Process that loses Service 1 never gets one again, so the parent stays stale for the rest of the render instead of being reset by a reissued id.

🤖 (generated) 🧑‍💻 (reviewed)
